### PR TITLE
Refactor de DTO de canción y nuevos endpoints para banner y canciones de músico

### DIFF
--- a/backend/src/main/java/com/footalentgroup/configuration/SecurityConfig.java
+++ b/backend/src/main/java/com/footalentgroup/configuration/SecurityConfig.java
@@ -57,10 +57,18 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/swagger-ui/**"
                         ).permitAll()
-                        .requestMatchers(HttpMethod.GET, "/songs", "/songs/{id}").permitAll()
-                        .requestMatchers("/songs/**").hasRole(Role.MUSICIAN.name())
-                        .requestMatchers(HttpMethod.GET, "/musician-profile/*").permitAll()
+                        .requestMatchers(HttpMethod.GET,
+                                "/songs",
+                                "/songs/{id}",
+                                "/songs/musician/{id}",
+                                "/musician-profile/{id}",
+                                "/musician-profile/{id}/banner",
+                                "/musician-profile/search"
+                        ).permitAll()
+                        .requestMatchers(HttpMethod.POST, "/songs").hasRole(Role.MUSICIAN.name())
+                        .requestMatchers(HttpMethod.PUT, "/songs/{id}").hasRole(Role.MUSICIAN.name())
                         .requestMatchers(HttpMethod.PUT, "/musician-profile").hasRole(Role.MUSICIAN.name())
+                        .requestMatchers(HttpMethod.PUT, "/musician-profile/banner").hasRole(Role.MUSICIAN.name())
                         .anyRequest().authenticated()
                 )
                 .authenticationProvider(authenticationProvider())

--- a/backend/src/main/java/com/footalentgroup/controllers/MusicianProfileController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/MusicianProfileController.java
@@ -1,8 +1,10 @@
 package com.footalentgroup.controllers;
 
+import com.footalentgroup.models.dtos.request.BannerUploadReqestDto;
 import com.footalentgroup.models.dtos.request.MusicianProfileRequestDto;
 import com.footalentgroup.models.dtos.request.MusicianSearchRequestDTO;
 import com.footalentgroup.models.dtos.response.ApiResponse;
+import com.footalentgroup.models.dtos.response.BannerResponseDto;
 import com.footalentgroup.services.MusicianProfileService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -46,9 +48,21 @@ public class MusicianProfileController {
     @Operation(summary = "Buscar musicos por nombre y genero (paginado)")
     @GetMapping("/search")
     public ResponseEntity<?> searchMusicians(@ParameterObject @Valid MusicianSearchRequestDTO requestDto){
-
         return ResponseEntity
                 .ok()
                 .body(this.musicService.searchMusicians(requestDto));
+    }
+
+    @Operation(summary = "Actualiza el banner del perfil del músico autenticado", security= @SecurityRequirement(name = "bearer-key"))
+    @PutMapping(value = "/banner", consumes = "multipart/form-data")
+    public ResponseEntity<?> updateBanner(@ModelAttribute @Valid BannerUploadReqestDto reqest){
+        this.musicService.updateBanner(reqest);
+        return ResponseEntity.ok().body(new ApiResponse<>("Banner actualizado con exito"));
+    }
+
+    @Operation(summary = "Obtiene el banner del perfil de un músico por su ID")
+    @GetMapping("/{id}/banner")
+    public ResponseEntity<BannerResponseDto> getBanner(@PathVariable Long id) {
+        return ResponseEntity.ok(this.musicService.getBannerByMusicianId(id));
     }
 }

--- a/backend/src/main/java/com/footalentgroup/controllers/SongController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/SongController.java
@@ -50,6 +50,13 @@ public class SongController {
         return ResponseEntity.ok().body(songService.getAllSongs(pageable));
     }
 
+    @GetMapping("musician/{id}")
+    @Operation(summary = "Obtiene todas las canciones de un artista por su ID")
+    public ResponseEntity<?> getAllSongsByMusicianId(@PathVariable Long id,@ParameterObject @Valid SongPageRequestDto request) {
+        Pageable pageable = PageRequest.of(request.getPage(), request.getSize(), request.getSort());
+        return ResponseEntity.ok().body(songService.getAllSongsByMusicianId(id,pageable));
+    }
+
     @PutMapping(value = "/{id}", consumes = "multipart/form-data")
     @Operation(summary = "Actualiza una canción por ID (requiere autenticación, solo el autor puede editar)", security = @SecurityRequirement(name = "bearer-key"))
     public ResponseEntity<?> updateSong(@PathVariable Long id, @ModelAttribute @Valid SongUploadRequestDto request) {

--- a/backend/src/main/java/com/footalentgroup/models/dtos/mapper/MusicProfileMapper.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/mapper/MusicProfileMapper.java
@@ -1,5 +1,6 @@
 package com.footalentgroup.models.dtos.mapper;
 
+import com.footalentgroup.models.dtos.request.BannerUploadReqestDto;
 import com.footalentgroup.models.dtos.request.MusicianProfileRequestDto;
 import com.footalentgroup.models.dtos.response.MusicianProfileResponseDto;
 import com.footalentgroup.models.entities.MusicianProfileEntity;
@@ -17,8 +18,7 @@ public interface MusicProfileMapper{
     MusicianProfileResponseDto toResponse(MusicianProfileEntity entity);
 
     @Mapping(target = "photoUrl", ignore = true)
-    void updateEntity(MusicianProfileRequestDto dto, @MappingTarget MusicianProfileEntity musicEntityProfile);
-
+    void updateEntity(MusicianProfileRequestDto dto, @MappingTarget MusicianProfileEntity entity);
 
 
 }

--- a/backend/src/main/java/com/footalentgroup/models/dtos/mapper/SongMapper.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/mapper/SongMapper.java
@@ -19,11 +19,14 @@ import java.util.stream.Collectors;
 public interface SongMapper {
 
     @Mapping(target = "audioUrl", ignore = true)
+    @Mapping(target = "spotifyUrl", ignore = true)
     SongEntity toEntity(SongUploadRequestDto dto);
 
     @Mapping(target = "musicianInfo", expression = "java(mapMusicianInfo(song.getMusicianProfile()))")
     SongResponseDto toSongResponseDto(SongEntity song);
 
+    @Mapping(target = "audioUrl", ignore = true)
+    @Mapping(target = "spotifyUrl", ignore = true)
     void updateEntity(SongUploadRequestDto requestDto, @MappingTarget SongEntity song);
 
 

--- a/backend/src/main/java/com/footalentgroup/models/dtos/request/BannerUploadReqestDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/request/BannerUploadReqestDto.java
@@ -1,0 +1,14 @@
+package com.footalentgroup.models.dtos.request;
+
+import com.footalentgroup.validators.ImageFile;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.web.multipart.MultipartFile;
+
+public record BannerUploadReqestDto(
+        @ImageFile
+        MultipartFile banner,
+
+        @Schema(description = "Campo para indicar que se desea eliminar el banner", defaultValue = "false")
+        boolean deleteBanner
+) {
+}

--- a/backend/src/main/java/com/footalentgroup/models/dtos/request/MusicianProfileRequestDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/request/MusicianProfileRequestDto.java
@@ -1,6 +1,7 @@
 package com.footalentgroup.models.dtos.request;
 
 import com.footalentgroup.validators.ImageFile;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import org.springframework.web.multipart.MultipartFile;
@@ -8,30 +9,40 @@ import org.springframework.web.multipart.MultipartFile;
 public record MusicianProfileRequestDto(
 
         @NotBlank(message = "El nombre de artista/banda no puede estar vacío")
+        @Schema(description = "Nombre artístico del artista o banda", example = "Los Rockeros", required = true)
         String stageName,
 
         @ImageFile
+        @Schema(description = "Archivo de imagen (jpg, jpeg, png, webp)")
         MultipartFile photo,
 
+        @Schema(description = "Indica si se debe eliminar la foto actual", example = "false")
         boolean deletePhoto,
 
+        @Schema(description = "Género musical principal", example = "Rock", required = true)
         @NotBlank(message = "El genero no debe estar vacio")
         String genre,
 
+        @Schema(description = "País de origen", example = "Argentina", required = true)
         @NotBlank(message = "El paíz no debe estar vacio")
         String country,
 
+        @Schema(description = "Número de WhatsApp de contacto", example = "+50660000000")
         String whatsapp,
 
+        @Schema(description = "URL del perfil de Spotify", example = "https://open.spotify.com/artist/abc123")
         @Pattern(regexp = "^(https?://)?(www\\.)?spotify\\.com/.*$", message = "Debe ser una URL válida de Spotify")
         String spotifyUrl,
 
+        @Schema(description = "URL del canal de YouTube", example = "https://www.youtube.com/channel/xyz456")
         @Pattern(regexp = "^(https?://)?(www\\.)?youtube\\.com/.*$", message = "Debe ser una URL válida de YouTube")
         String youtubeUrl,
 
+        @Schema(description = "URL del perfil de Instagram", example = "https://www.instagram.com/mi_artista")
         @Pattern(regexp = "^(https?://)?(www\\.)?instagram\\.com/.*$", message = "Debe ser una URL válida de Instagram")
         String instagramUrl,
 
+        @Schema(description = "URL del perfil de TikTok", example = "https://www.tiktok.com/@mi_artista")
         @Pattern(regexp = "^(https?://)?(www\\.)?tiktok\\.com/.*$", message = "Debe ser una URL válida de TikTok")
         String tiktokUrl
 ) {

--- a/backend/src/main/java/com/footalentgroup/models/dtos/request/SongPageRequestDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/request/SongPageRequestDto.java
@@ -23,7 +23,7 @@ public class SongPageRequestDto {
     @Parameter(description = "Tamaño de página", example = "10")
     private int size = 10;
 
-    @Pattern(regexp = "title|artist|duration", message = "El campo de ordenamiento no es válido")
+    @Pattern(regexp = "title|artist", message = "El campo de ordenamiento no es válido")
     @Parameter(description = "Campo por el que ordenar", example = "title")
     private String sortBy = "title";
 

--- a/backend/src/main/java/com/footalentgroup/models/dtos/request/SongUploadRequestDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/request/SongUploadRequestDto.java
@@ -1,6 +1,7 @@
 package com.footalentgroup.models.dtos.request;
 
 import com.footalentgroup.validators.MusicFile;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -11,24 +12,31 @@ import java.util.Date;
 
 public record SongUploadRequestDto(
         @NotBlank(message = "El título es obligatorio.")
+        @Schema(description = "Título de la canción", example = "Mi Canción Favorita", required = true)
         String title,
 
         @MusicFile(message = "El archivo de música debe ser válido (mp3, wav, flac, etc.).")
+        @Schema(description = "Archivo de audio en formato mp3, wav, etc.")
         MultipartFile audio,
 
+        @Schema(description = "Enlace opcional a Spotify", example = "https://open.spotify.com/track/abc123")
         @Pattern(regexp = "^(https?://(www\\.)?spotify\\.com/.*)?$", message = "El enlace de Spotify no es válido.")
         String spotifyUrl,
 
+        @Schema(description = "Enlace opcional a YouTube", example = "https://www.youtube.com/watch?v=xyz456")
         @Pattern(regexp = "^(https?://(www\\.)?youtube\\.com/.*)?$", message = "El enlace de YouTube no es válido.")
         String youtubeUrl,
 
+        @Schema(description = "Enlace opcional a SoundCloud", example = "https://soundcloud.com/artista/cancion")
         @Pattern(regexp = "^(https?://(www\\.)?soundcloud\\.com/.*)?$", message = "El enlace de SoundCloud no es válido.")
         String soundcloudUrl,
 
+        @Schema(description = "Fecha de lanzamiento de la canción", example = "2024-10-15")
         @NotNull(message = "La fecha de lanzamiento es obligatoria.")
         @DateTimeFormat(pattern = "yyyy-MM-dd")
         Date releaseDate,
 
+        @Schema(description = "Género musical", example = "Reggaetón",required = true)
         @NotBlank(message = "El género es obligatorio.")
         String genre
 ) {

--- a/backend/src/main/java/com/footalentgroup/models/dtos/request/SongUploadRequestDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/request/SongUploadRequestDto.java
@@ -1,5 +1,6 @@
 package com.footalentgroup.models.dtos.request;
 
+import com.footalentgroup.models.enums.SongSourceType;
 import com.footalentgroup.validators.MusicFile;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -15,29 +16,25 @@ public record SongUploadRequestDto(
         @Schema(description = "Título de la canción", example = "Mi Canción Favorita", required = true)
         String title,
 
+        @Schema(description = "Género musical", example = "Reggaetón",required = true)
+        @NotBlank(message = "El género es obligatorio.")
+        String genre,
+
+        @NotNull(message = "Debe indicar el tipo de fuente de la canción.")
+        @Schema(description = "Origen del contenido de la canción: FILE, SPOTIFY", example = "FILE")
+        SongSourceType sourceType,
+
         @MusicFile(message = "El archivo de música debe ser válido (mp3, wav, flac, etc.).")
         @Schema(description = "Archivo de audio en formato mp3, wav, etc.")
         MultipartFile audio,
 
-        @Schema(description = "Enlace opcional a Spotify", example = "https://open.spotify.com/track/abc123")
-        @Pattern(regexp = "^(https?://(www\\.)?spotify\\.com/.*)?$", message = "El enlace de Spotify no es válido.")
+        @Schema(description = "Enlace opcional a Spotify", example = "https://open.spotify.com/track/3D24ErT1MMmUfXWotSj2A2", required = false)
+        @Pattern(regexp = "^https://open\\.spotify\\.com(/[^/]+)?/track/[a-zA-Z0-9]{22}([?&].*)?$", message = "El enlace de Spotify debe ser válido y apuntar a una canción individual (no álbum, artista o playlist).")
         String spotifyUrl,
 
         @Schema(description = "Enlace opcional a YouTube", example = "https://www.youtube.com/watch?v=xyz456")
         @Pattern(regexp = "^(https?://(www\\.)?youtube\\.com/.*)?$", message = "El enlace de YouTube no es válido.")
-        String youtubeUrl,
+        String youtubeUrl
 
-        @Schema(description = "Enlace opcional a SoundCloud", example = "https://soundcloud.com/artista/cancion")
-        @Pattern(regexp = "^(https?://(www\\.)?soundcloud\\.com/.*)?$", message = "El enlace de SoundCloud no es válido.")
-        String soundcloudUrl,
-
-        @Schema(description = "Fecha de lanzamiento de la canción", example = "2024-10-15")
-        @NotNull(message = "La fecha de lanzamiento es obligatoria.")
-        @DateTimeFormat(pattern = "yyyy-MM-dd")
-        Date releaseDate,
-
-        @Schema(description = "Género musical", example = "Reggaetón",required = true)
-        @NotBlank(message = "El género es obligatorio.")
-        String genre
 ) {
 }

--- a/backend/src/main/java/com/footalentgroup/models/dtos/response/BannerResponseDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/response/BannerResponseDto.java
@@ -1,0 +1,3 @@
+package com.footalentgroup.models.dtos.response;
+
+public record BannerResponseDto(String bannerUrl) {}

--- a/backend/src/main/java/com/footalentgroup/models/dtos/response/SongResponseDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/response/SongResponseDto.java
@@ -6,12 +6,10 @@ public record SongResponseDto(
 
         Long id,
         String title,
+        String genre,
         String audioUrl,
         String spotifyUrl,
         String youtubeUrl,
-        String soundcloudUrl,
-        Date releaseDate,
-        String genre,
         MusicianInfoReponseDto musicianInfo
         //String albumCoverImageUrl, // existira albun?
         //Boolean isPublished //

--- a/backend/src/main/java/com/footalentgroup/models/entities/MusicianProfileEntity.java
+++ b/backend/src/main/java/com/footalentgroup/models/entities/MusicianProfileEntity.java
@@ -23,6 +23,9 @@ public class MusicianProfileEntity {
     private String photoUrl;
     private String photoPublicId;
 
+    private String bannerUrl;
+    private String bannerPublicId;
+
     //Contact Data
     private String whatsapp;
     private String spotifyUrl;

--- a/backend/src/main/java/com/footalentgroup/models/entities/SongEntity.java
+++ b/backend/src/main/java/com/footalentgroup/models/entities/SongEntity.java
@@ -3,7 +3,6 @@ package com.footalentgroup.models.entities;
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 import java.util.Date;
 
@@ -26,7 +25,7 @@ public class SongEntity {
 
     String spotifyUrl;
     String youtubeUrl;
-    String soundcloadUrl;
+    String soundcloudUrl;
 
     @Column(nullable = false)
     Date releaseDate;

--- a/backend/src/main/java/com/footalentgroup/models/entities/SongEntity.java
+++ b/backend/src/main/java/com/footalentgroup/models/entities/SongEntity.java
@@ -19,19 +19,14 @@ public class SongEntity {
     @Column(nullable = false)
     String title;
 
+    @Column(nullable = false)
+    String genre;
+
     String audioUrl;
     String audioPublicId;
 
-
     String spotifyUrl;
     String youtubeUrl;
-    String soundcloudUrl;
-
-    @Column(nullable = false)
-    Date releaseDate;
-
-    @Column(nullable = false)
-    String genre;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "musician_id", nullable = false)

--- a/backend/src/main/java/com/footalentgroup/models/enums/SongSourceType.java
+++ b/backend/src/main/java/com/footalentgroup/models/enums/SongSourceType.java
@@ -1,0 +1,6 @@
+package com.footalentgroup.models.enums;
+
+public enum SongSourceType {
+    FILE,
+    SPOTIFY
+}

--- a/backend/src/main/java/com/footalentgroup/repositories/SongRepository.java
+++ b/backend/src/main/java/com/footalentgroup/repositories/SongRepository.java
@@ -1,6 +1,8 @@
 package com.footalentgroup.repositories;
 
 import com.footalentgroup.models.entities.SongEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,4 +13,5 @@ public interface SongRepository extends JpaRepository<SongEntity,Long> {
 
     Optional<SongEntity> findByIdAndMusicianProfile_User_Email(Long idSong, String email);
 
+    Page<SongEntity> findByMusicianProfileId(Long idMusician, Pageable pageable);
 }

--- a/backend/src/main/java/com/footalentgroup/services/MusicianProfileService.java
+++ b/backend/src/main/java/com/footalentgroup/services/MusicianProfileService.java
@@ -1,7 +1,9 @@
 package com.footalentgroup.services;
 
+import com.footalentgroup.models.dtos.request.BannerUploadReqestDto;
 import com.footalentgroup.models.dtos.request.MusicianProfileRequestDto;
 import com.footalentgroup.models.dtos.request.MusicianSearchRequestDTO;
+import com.footalentgroup.models.dtos.response.BannerResponseDto;
 import com.footalentgroup.models.dtos.response.MusicianProfileResponseDto;
 import com.footalentgroup.models.entities.UserEntity;
 import org.springframework.data.domain.Page;
@@ -15,4 +17,8 @@ public interface MusicianProfileService {
     void updateProfile(MusicianProfileRequestDto requestDto);
 
     Page<MusicianProfileResponseDto> searchMusicians(MusicianSearchRequestDTO requestDTO);
+
+    void updateBanner(BannerUploadReqestDto reqest);
+
+    BannerResponseDto getBannerByMusicianId(Long id);
 }

--- a/backend/src/main/java/com/footalentgroup/services/SongService.java
+++ b/backend/src/main/java/com/footalentgroup/services/SongService.java
@@ -15,6 +15,8 @@ public interface SongService {
 
     SongResponseDto updateSong(Long idSong, SongUploadRequestDto request);
 
+    PageResponseDto<SongResponseDto> getAllSongsByMusicianId(Long idMusician, Pageable pageable);
+
     void deleteSong(Long id);
 
 


### PR DESCRIPTION
Se eliminaron campos innecesarios del DTO usado para subir y actualizar canciones.  
Se implementaron nuevos endpoints para subir y obtener el banner del perfil del músico.  
También se añadió un endpoint para obtener todas las canciones asociadas a un músico específico.