### PR TITLE
Associate tickets with event entity

### DIFF
--- a/backend/src/main/java/com/footalentgroup/controllers/EventController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/EventController.java
@@ -28,8 +28,6 @@ public class EventController {
     @PostMapping(consumes = "multipart/form-data")
     @PreAuthorize("hasRole('MUSICIAN')")
     public ResponseEntity<?> create(@ModelAttribute @Valid EventRequestDto eventDto) {
-        eventDto.doDefault();
-
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(this.eventService.create(eventDto));
@@ -38,7 +36,6 @@ public class EventController {
     @PutMapping(value = ID_ID, consumes = "multipart/form-data")
     @PreAuthorize("hasRole('MUSICIAN')")
     public ResponseEntity<?> update(@PathVariable Long id, @ModelAttribute @Valid EventRequestDto eventDto) {
-        eventDto.doDefault();
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(this.eventService.update(id, eventDto));

--- a/backend/src/main/java/com/footalentgroup/models/dtos/mapper/EventMapper.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/mapper/EventMapper.java
@@ -1,27 +1,31 @@
 package com.footalentgroup.models.dtos.mapper;
 
 import com.footalentgroup.models.dtos.request.EventRequestDto;
+import com.footalentgroup.models.dtos.request.TicketRequestDto;
 import com.footalentgroup.models.dtos.response.EventResponseDto;
 import com.footalentgroup.models.entities.EventEntity;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
+import com.footalentgroup.models.entities.TicketEntity;
+import org.mapstruct.*;
 
-@Mapper(componentModel = "spring")
+import java.util.List;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface EventMapper {
 
-    @Mapping(target = "id", ignore = true)
+    // ========== EVENT MAPPINGS ==========
+
     @Mapping(target = "image", ignore = true)
-    @Mapping(target = "imagePublicId", ignore = true)
-    @Mapping(target = "musician", ignore = true)
     EventEntity toEntity(EventRequestDto dto);
 
     @Mapping(target = "musicianId", source = "musician.id")
     EventResponseDto toDto(EventEntity entity);
 
-    @Mapping(target = "id", ignore = true)
     @Mapping(target = "image", ignore = true)
-    @Mapping(target = "imagePublicId", ignore = true)
-    @Mapping(target = "musician", ignore = true)
     void updateEntity(EventRequestDto dto, @MappingTarget EventEntity entity);
+
+    // ========== TICKET MAPPINGS ==========
+
+    List<TicketEntity> toTicketEntityList(List<TicketRequestDto> dto);
+
+    TicketEntity toTicketEntity(TicketRequestDto dto);
 }

--- a/backend/src/main/java/com/footalentgroup/models/dtos/request/EventRequestDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/request/EventRequestDto.java
@@ -1,9 +1,8 @@
 package com.footalentgroup.models.dtos.request;
 
-import com.footalentgroup.models.enums.EventTicket;
 import com.footalentgroup.models.enums.EventType;
 import com.footalentgroup.validators.ImageFile;
-import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -12,10 +11,11 @@ import lombok.Data;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Data
@@ -55,10 +55,8 @@ public class EventRequestDto {
 
     private Boolean deleteImage;
 
-    private EventTicket ticket;
-
-    @DecimalMin(value = "0.0", inclusive = false, message = "El precio debe ser mayor a cero.")
-    private BigDecimal price;
+    @Valid
+    private List<TicketRequestDto> tickets;
 
     private Boolean active;
 
@@ -74,12 +72,12 @@ public class EventRequestDto {
             deleteImage = false;
         }
 
-        if (Objects.isNull(ticket)) {
-            ticket = EventTicket.FreeEvent;
+        if (!Objects.isNull(tickets) && !tickets.isEmpty()) {
+            tickets.forEach(TicketRequestDto::doDefault);
         }
 
-        if (Objects.isNull(price)) {
-            price = BigDecimal.ZERO;
+        if (Objects.isNull(active)) {
+            active = true;
         }
     }
 }

--- a/backend/src/main/java/com/footalentgroup/models/dtos/request/TicketRequestDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/request/TicketRequestDto.java
@@ -1,0 +1,26 @@
+package com.footalentgroup.models.dtos.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class TicketRequestDto {
+
+    @NotBlank(message = "La ubicación de la entrada es obligatoria.")
+    private String location;
+
+    private BigDecimal price;
+
+    public void doDefault() {
+        if (Objects.isNull(price) || price.compareTo(BigDecimal.ZERO) < 0) {
+            price = BigDecimal.ZERO;
+        }
+    }
+}

--- a/backend/src/main/java/com/footalentgroup/models/dtos/response/EventResponseDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/response/EventResponseDto.java
@@ -2,14 +2,13 @@ package com.footalentgroup.models.dtos.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.footalentgroup.models.enums.EventTicket;
 import com.footalentgroup.models.enums.EventType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 @Data
 @AllArgsConstructor
@@ -28,8 +27,7 @@ public class EventResponseDto {
     private String location;
     private String description;
     private String image;
-    private EventTicket ticket;
-    private BigDecimal price;
     private Boolean active;
+    private List<TicketResponseDto> tickets;
     private Long musicianId;
 }

--- a/backend/src/main/java/com/footalentgroup/models/dtos/response/TicketResponseDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/response/TicketResponseDto.java
@@ -1,0 +1,16 @@
+package com.footalentgroup.models.dtos.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TicketResponseDto {
+    private Long id;
+    private String location;
+    private BigDecimal price;
+}

--- a/backend/src/main/java/com/footalentgroup/models/entities/EventEntity.java
+++ b/backend/src/main/java/com/footalentgroup/models/entities/EventEntity.java
@@ -1,6 +1,6 @@
 package com.footalentgroup.models.entities;
 
-import com.footalentgroup.models.enums.EventTicket;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.footalentgroup.models.enums.EventType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -9,9 +9,10 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.type.TrueFalseConverter;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @Builder
@@ -58,14 +59,12 @@ public class EventEntity {
     @Column(nullable = true)
     private String imagePublicId;
 
-    @Enumerated(EnumType.STRING)
-    private EventTicket ticket;
-
-    @Column(nullable = true)
-    private BigDecimal price;
-
     @Convert(converter = TrueFalseConverter.class)
     private Boolean active;
+
+    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
+    private List<TicketEntity> tickets = new ArrayList<>();
 
     @ManyToOne
     @JoinColumn(name = "musician_id", nullable = false)

--- a/backend/src/main/java/com/footalentgroup/models/entities/TicketEntity.java
+++ b/backend/src/main/java/com/footalentgroup/models/entities/TicketEntity.java
@@ -1,0 +1,33 @@
+package com.footalentgroup.models.entities;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "tickets")
+public class TicketEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String location;
+
+    @Column(nullable = false)
+    private BigDecimal price;
+
+    @ManyToOne
+    @JoinColumn(name = "event_id", nullable = false)
+    @JsonBackReference
+    private EventEntity event;
+}

--- a/backend/src/main/java/com/footalentgroup/models/enums/EventTicket.java
+++ b/backend/src/main/java/com/footalentgroup/models/enums/EventTicket.java
@@ -1,6 +1,0 @@
-package com.footalentgroup.models.enums;
-
-public enum EventTicket {
-    TicketedEvent,
-    FreeEvent
-}

--- a/backend/src/main/java/com/footalentgroup/services/impl/EventServiceImpl.java
+++ b/backend/src/main/java/com/footalentgroup/services/impl/EventServiceImpl.java
@@ -36,6 +36,8 @@ public class EventServiceImpl implements EventService {
     @Override
     @Transactional
     public EventResponseDto create(EventRequestDto eventDto) {
+        eventDto.doDefault();
+
         MusicianProfileEntity musician = this.musicianRepository
                 .findById(eventDto.getMusicianId())
                 .orElseThrow(() -> new NotFoundException("Musico/Banda no encontrado"));
@@ -50,6 +52,8 @@ public class EventServiceImpl implements EventService {
     @Override
     @Transactional
     public EventResponseDto update(Long id, EventRequestDto eventDto) {
+        eventDto.doDefault();
+
         EventEntity event = this.eventRepository
                 .findById(id)
                 .orElseThrow(() -> new NotFoundException("Evento no encontrado: " + id));
@@ -69,12 +73,18 @@ public class EventServiceImpl implements EventService {
     }
 
     private void updateImage(MultipartFile file, EventEntity event, Boolean deleteImage) {
-        if (deleteImage && event.getImagePublicId() != null && !event.getImagePublicId().isEmpty()) {
-            cloudinaryService.deleteImage(event.getImagePublicId());
-            event.setImage(null);
-            event.setImagePublicId(null);
-        }
+        if (deleteImage) {
+            if (event.getImagePublicId() != null && !event.getImagePublicId().isEmpty()) {
+                cloudinaryService.deleteImage(event.getImagePublicId());
+                event.setImage(null);
+                event.setImagePublicId(null);
+            }
+        } else if (file != null && !file.isEmpty()) {
+            if (event.getImagePublicId() != null && !event.getImagePublicId().isEmpty()) {
+                cloudinaryService.deleteImage(event.getImagePublicId());
+            }
 
-        saveImage(file, event);
+            saveImage(file, event);
+        }
     }
 }


### PR DESCRIPTION
- Se establece la relación entre las entradas (`tickets`) y el evento.
- Se ajusta la lógica de actualización de la imagen del evento.
- Se mejora el `mapper` de Event para facilitar el manejo de la entidad y sus relaciones.

## Postman

### Petición POST

![event-post](https://github.com/user-attachments/assets/0b2a7432-8117-42cc-9d2f-bfc3071b435c)

### Petición PUT

![event-put](https://github.com/user-attachments/assets/0c61b1ea-519f-4888-88ec-e4070b804f38)

### Petición GET

![event-get](https://github.com/user-attachments/assets/c016c4d4-e0d5-477f-a4dc-ad4474ad600a)