### PR TITLE
Event searches

### DIFF
--- a/backend/src/main/java/com/footalentgroup/configuration/SecurityConfig.java
+++ b/backend/src/main/java/com/footalentgroup/configuration/SecurityConfig.java
@@ -65,6 +65,12 @@ public class SecurityConfig {
                                 "/musician-profile/{id}/banner",
                                 "/musician-profile/search"
                         ).permitAll()
+                        .requestMatchers(
+                                HttpMethod.GET,
+                                "/events/{id}",
+                                "/events/search",
+                                "/events/musician/{musicianId}"
+                        ).permitAll()
                         .requestMatchers(HttpMethod.POST, "/songs").hasRole(Role.MUSICIAN.name())
                         .requestMatchers(HttpMethod.PUT, "/songs/{id}").hasRole(Role.MUSICIAN.name())
                         .requestMatchers(HttpMethod.PUT, "/musician-profile").hasRole(Role.MUSICIAN.name())

--- a/backend/src/main/java/com/footalentgroup/controllers/EventController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/EventController.java
@@ -15,6 +15,8 @@ import org.springframework.web.bind.annotation.*;
 public class EventController {
     public static final String EVENTS = "/events";
     public static final String ID_ID = "/{id}";
+    public static final String SEARCH = "/search";
+    public static final String ID_MUSICIAN = "/musician/{musicianId}";
 
     private final EventServiceImpl eventService;
 
@@ -23,6 +25,27 @@ public class EventController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(this.eventService.read(id));
+    }
+
+    @GetMapping(SEARCH)
+    public ResponseEntity<?> search(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "3") int size
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(this.eventService.search(page, size));
+    }
+
+    @GetMapping(ID_MUSICIAN)
+    public ResponseEntity<?> searchByMusician(
+            @PathVariable Long musicianId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "3") int size
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(this.eventService.searchByMusician(musicianId, page, size));
     }
 
     @PostMapping(consumes = "multipart/form-data")

--- a/backend/src/main/java/com/footalentgroup/models/dtos/mapper/EventMapper.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/mapper/EventMapper.java
@@ -3,6 +3,7 @@ package com.footalentgroup.models.dtos.mapper;
 import com.footalentgroup.models.dtos.request.EventRequestDto;
 import com.footalentgroup.models.dtos.request.TicketRequestDto;
 import com.footalentgroup.models.dtos.response.EventResponseDto;
+import com.footalentgroup.models.dtos.response.EventSimpleResponseDto;
 import com.footalentgroup.models.entities.EventEntity;
 import com.footalentgroup.models.entities.TicketEntity;
 import org.mapstruct.*;
@@ -22,6 +23,10 @@ public interface EventMapper {
 
     @Mapping(target = "image", ignore = true)
     void updateEntity(EventRequestDto dto, @MappingTarget EventEntity entity);
+
+    EventSimpleResponseDto toSimpleDto(EventEntity entity);
+
+    List<EventSimpleResponseDto> toSimpleDtoList(List<EventEntity> entities);
 
     // ========== TICKET MAPPINGS ==========
 

--- a/backend/src/main/java/com/footalentgroup/models/dtos/response/EventSimpleResponseDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/response/EventSimpleResponseDto.java
@@ -1,0 +1,19 @@
+package com.footalentgroup.models.dtos.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EventSimpleResponseDto {
+    private Long id;
+    private String name;
+    private String category;
+    private LocalDate date;
+    private String description;
+    private String image;
+}

--- a/backend/src/main/java/com/footalentgroup/models/dtos/response/PagedResponseDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/response/PagedResponseDto.java
@@ -1,0 +1,18 @@
+package com.footalentgroup.models.dtos.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PagedResponseDto<T> {
+    private List<T> data;
+    private int currentPage;
+    private int totalPages;
+    private long totalElements;
+    private int pageSize;
+}

--- a/backend/src/main/java/com/footalentgroup/repositories/EventRepository.java
+++ b/backend/src/main/java/com/footalentgroup/repositories/EventRepository.java
@@ -1,7 +1,13 @@
 package com.footalentgroup.repositories;
 
 import com.footalentgroup.models.entities.EventEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+
 public interface EventRepository extends JpaRepository<EventEntity, Long> {
+    Page<EventEntity> findByDateAfterOrderByDateAsc(LocalDate date, Pageable pageable);
+    Page<EventEntity> findByMusicianIdAndDateAfterOrderByDateAsc(Long musicianId, LocalDate date, Pageable pageable);
 }

--- a/backend/src/main/java/com/footalentgroup/services/EventService.java
+++ b/backend/src/main/java/com/footalentgroup/services/EventService.java
@@ -2,9 +2,13 @@ package com.footalentgroup.services;
 
 import com.footalentgroup.models.dtos.request.EventRequestDto;
 import com.footalentgroup.models.dtos.response.EventResponseDto;
+import com.footalentgroup.models.dtos.response.EventSimpleResponseDto;
+import com.footalentgroup.models.dtos.response.PagedResponseDto;
 
 public interface EventService {
     EventResponseDto read(Long id);
+    PagedResponseDto<EventSimpleResponseDto> search(int page, int size);
+    PagedResponseDto<EventSimpleResponseDto> searchByMusician(Long musicianId, int page, int size);
     EventResponseDto create(EventRequestDto eventDto);
     EventResponseDto update(Long id, EventRequestDto eventDto);
 }

--- a/backend/src/main/java/com/footalentgroup/services/impl/EventServiceImpl.java
+++ b/backend/src/main/java/com/footalentgroup/services/impl/EventServiceImpl.java
@@ -4,6 +4,8 @@ import com.footalentgroup.exceptions.NotFoundException;
 import com.footalentgroup.models.dtos.mapper.EventMapper;
 import com.footalentgroup.models.dtos.request.EventRequestDto;
 import com.footalentgroup.models.dtos.response.EventResponseDto;
+import com.footalentgroup.models.dtos.response.EventSimpleResponseDto;
+import com.footalentgroup.models.dtos.response.PagedResponseDto;
 import com.footalentgroup.models.entities.EventEntity;
 import com.footalentgroup.models.entities.MusicianProfileEntity;
 import com.footalentgroup.models.entities.TicketEntity;
@@ -13,9 +15,13 @@ import com.footalentgroup.services.CloudinaryService;
 import com.footalentgroup.services.EventService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
@@ -33,6 +39,43 @@ public class EventServiceImpl implements EventService {
                 .findById(id)
                 .orElseThrow(() -> new NotFoundException("Evento no encontrado: " + id));
         return this.eventMapper.toDto(event);
+    }
+
+    @Override
+    public PagedResponseDto<EventSimpleResponseDto> search(int page, int size) {
+        Page<EventEntity> eventPage = this.eventRepository
+                .findByDateAfterOrderByDateAsc(
+                        LocalDate.now(),
+                        PageRequest.of(page, size, Sort.by("date").ascending())
+                );
+
+        List<EventSimpleResponseDto> events = this.eventMapper.toSimpleDtoList(eventPage.getContent());
+        return new PagedResponseDto<>(
+                events,
+                eventPage.getNumber(),
+                eventPage.getTotalPages(),
+                eventPage.getTotalElements(),
+                eventPage.getSize()
+        );
+    }
+
+    @Override
+    public PagedResponseDto<EventSimpleResponseDto> searchByMusician(Long musicianId, int page, int size) {
+        Page<EventEntity> eventPage = this.eventRepository
+                .findByMusicianIdAndDateAfterOrderByDateAsc(
+                        musicianId,
+                        LocalDate.now(),
+                        PageRequest.of(page, size, Sort.by("date").ascending())
+                );
+
+        List<EventSimpleResponseDto> events = this.eventMapper.toSimpleDtoList(eventPage.getContent());
+        return new PagedResponseDto<>(
+                events,
+                eventPage.getNumber(),
+                eventPage.getTotalPages(),
+                eventPage.getTotalElements(),
+                eventPage.getSize()
+        );
     }
 
     @Override


### PR DESCRIPTION
Se agregaron los siguientes endpoints públicos para obtener y buscar eventos:
- `GET /events/{id}`: obtener toda la información del evento por ID.
- `GET /events/search?page=0&size=3`: obtener información básica de eventos ordenados por fecha desde el más cercano al más lejano.
- `GET /events/musician/{musicianId}?page=0&size=3`: obtener  información básica de eventos de un músico específico, ordenados por fecha desde el más cercano al más lejano.