### PR TITLE
Registro perfil de fan 

### DIFF
--- a/backend/src/main/java/com/footalentgroup/configuration/SecurityConfig.java
+++ b/backend/src/main/java/com/footalentgroup/configuration/SecurityConfig.java
@@ -65,6 +65,9 @@ public class SecurityConfig {
                                 "/musician-profile/{id}/banner",
                                 "/musician-profile/search"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.GET,
+                                "/fan-profile/{id}"
+                        ).permitAll()
                         .requestMatchers(
                                 HttpMethod.GET,
                                 "/events/{id}",

--- a/backend/src/main/java/com/footalentgroup/controllers/FanProfileController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/FanProfileController.java
@@ -31,6 +31,7 @@ public class FanProfileController {
     @Operation(summary = "Actualiza perfil del fan, solo usuario autenticado", security= @SecurityRequirement(name = "bearer-key"))
     @PutMapping(consumes = "multipart/form-data")
     public ResponseEntity<?> updateFanProfile(@ModelAttribute @Valid FanProfileRequestDto requestDto){
+        System.out.println("Foto recibida: " + (requestDto.photo() != null ? requestDto.photo().getOriginalFilename() : "null"));
         this.fanProfileService.updateFanProfile(requestDto);
         return ResponseEntity
                 .ok()

--- a/backend/src/main/java/com/footalentgroup/controllers/FanProfileController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/FanProfileController.java
@@ -1,0 +1,39 @@
+package com.footalentgroup.controllers;
+
+
+import com.footalentgroup.models.dtos.request.FanProfileRequestDto;
+import com.footalentgroup.models.dtos.response.ApiResponse;
+import com.footalentgroup.services.FanProfileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping(FanProfileController.FAN)
+@RequiredArgsConstructor
+@Tag(name = "Fan Profile")
+public class FanProfileController {
+    public static final String FAN = "/fan-profile";
+    private final FanProfileService fanProfileService;
+
+    @Operation(summary = "Obtiene perfil del fan especificado por id")
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getFanProfileById(@PathVariable Long id){
+        return ResponseEntity
+                .ok()
+                .body(new ApiResponse<>(this.fanProfileService.getFanProfileById(id)));
+    }
+
+    @Operation(summary = "Actualiza perfil del fan, solo usuario autenticado", security= @SecurityRequirement(name = "bearer-key"))
+    @PutMapping(consumes = "multipart/form-data")
+    public ResponseEntity<?> updateFanProfile(@ModelAttribute @Valid FanProfileRequestDto requestDto){
+        this.fanProfileService.updateFanProfile(requestDto);
+        return ResponseEntity
+                .ok()
+                .body(new ApiResponse<>("Perfil de fan actualizado correctamente"));
+    }
+}

--- a/backend/src/main/java/com/footalentgroup/exceptions/FanProfileNotFoundException.java
+++ b/backend/src/main/java/com/footalentgroup/exceptions/FanProfileNotFoundException.java
@@ -1,0 +1,7 @@
+package com.footalentgroup.exceptions;
+
+public class FanProfileNotFoundException extends RuntimeException {
+    public FanProfileNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/footalentgroup/exceptions/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/footalentgroup/exceptions/GlobalExceptionHandler.java
@@ -100,4 +100,14 @@ public class GlobalExceptionHandler {
                 HttpStatus.NOT_FOUND.value()
         );
     }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(FanProfileNotFoundException.class)
+    public ErrorResponse fanProfileNotFound(FanProfileNotFoundException ex) {
+        return new ErrorResponse(
+                "FanProfileNotFoundException",
+                ex.getMessage(),
+                HttpStatus.NOT_FOUND.value()
+        );
+    }
 }

--- a/backend/src/main/java/com/footalentgroup/models/dtos/mapper/FanProfileMapper.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/mapper/FanProfileMapper.java
@@ -1,0 +1,20 @@
+package com.footalentgroup.models.dtos.mapper;
+
+import com.footalentgroup.models.dtos.request.FanProfileRequestDto;
+import com.footalentgroup.models.dtos.response.FanProfileResponseDto;
+import com.footalentgroup.models.entities.FanProfileEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+@Mapper(componentModel = "spring")
+public interface FanProfileMapper {
+    @Mapping(target="photoUrl", ignore = true)
+    FanProfileEntity toEntity(FanProfileRequestDto dto);
+
+    @Mapping(source = "photoUrl", target="photoUrl")
+    FanProfileResponseDto toResponse(FanProfileEntity entity);
+
+    @Mapping(target="photoUrl", ignore = true)
+    void updateEntity(FanProfileRequestDto dto, @MappingTarget FanProfileEntity entity);
+}

--- a/backend/src/main/java/com/footalentgroup/models/dtos/request/FanProfileRequestDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/request/FanProfileRequestDto.java
@@ -1,0 +1,23 @@
+package com.footalentgroup.models.dtos.request;
+
+import com.footalentgroup.validators.ImageFile;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public record FanProfileRequestDto (
+        @ImageFile
+        MultipartFile photo,
+
+        boolean deletePhoto,
+
+        @NotBlank(message = "El paíz no debe estar vacio")
+        String country,
+
+        @Size(min = 1, message = "Debe seleccionar al menos un género de interés")
+        List<@NotBlank(message = "El género no puede estar vacío") String> genreInterest
+        )
+{
+}

--- a/backend/src/main/java/com/footalentgroup/models/dtos/request/FanProfileRequestDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/request/FanProfileRequestDto.java
@@ -1,6 +1,7 @@
 package com.footalentgroup.models.dtos.request;
 
 import com.footalentgroup.validators.ImageFile;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import org.springframework.web.multipart.MultipartFile;
@@ -9,13 +10,17 @@ import java.util.List;
 
 public record FanProfileRequestDto (
         @ImageFile
+        @Schema(description = "Archivo de imagen (jpg, jpeg, png, webp)")
         MultipartFile photo,
 
+        @Schema(description = "Indica si se debe eliminar la foto actual", example = "false")
         boolean deletePhoto,
 
-        @NotBlank(message = "El paíz no debe estar vacio")
+        @Schema(description = "País de origen", example = "Argentina", required = true)
+        @NotBlank(message = "El pais no debe estar vacío")
         String country,
 
+        @Schema(description = "Géneros musicales", required = true)
         @Size(min = 1, message = "Debe seleccionar al menos un género de interés")
         List<@NotBlank(message = "El género no puede estar vacío") String> genreInterest
         )

--- a/backend/src/main/java/com/footalentgroup/models/dtos/response/FanProfileResponseDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/response/FanProfileResponseDto.java
@@ -1,0 +1,11 @@
+package com.footalentgroup.models.dtos.response;
+
+import java.util.List;
+
+public record FanProfileResponseDto (
+        String photoUrl,
+        List<String> genreInterest,
+        String country
+)
+{
+}

--- a/backend/src/main/java/com/footalentgroup/models/entities/FanProfileEntity.java
+++ b/backend/src/main/java/com/footalentgroup/models/entities/FanProfileEntity.java
@@ -1,0 +1,33 @@
+package com.footalentgroup.models.entities;
+
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Data
+@NoArgsConstructor
+@Table(name = "fan_profiles")
+public class FanProfileEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String photoUrl;
+    private String photoPublicId;
+
+    @ElementCollection
+    @CollectionTable(name = "fan_interest_genres", joinColumns = @JoinColumn(name = "fan_profile_id"))
+    @Column(name = "genre")
+    private List<String> genreInterest;
+
+    private String country;
+
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "id")
+    private UserEntity user;
+}

--- a/backend/src/main/java/com/footalentgroup/repositories/FanProfileRepository.java
+++ b/backend/src/main/java/com/footalentgroup/repositories/FanProfileRepository.java
@@ -1,0 +1,10 @@
+package com.footalentgroup.repositories;
+
+import com.footalentgroup.models.entities.FanProfileEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FanProfileRepository  extends JpaRepository<FanProfileEntity, Long> {
+    Optional<FanProfileEntity> findByUserEmail(String email);
+}

--- a/backend/src/main/java/com/footalentgroup/repositories/FanProfileRepository.java
+++ b/backend/src/main/java/com/footalentgroup/repositories/FanProfileRepository.java
@@ -1,6 +1,7 @@
 package com.footalentgroup.repositories;
 
 import com.footalentgroup.models.entities.FanProfileEntity;
+import com.footalentgroup.models.entities.MusicianProfileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/backend/src/main/java/com/footalentgroup/services/FanProfileService.java
+++ b/backend/src/main/java/com/footalentgroup/services/FanProfileService.java
@@ -10,4 +10,5 @@ public interface FanProfileService {
     void createFanProfile(UserEntity user);
 
     void updateFanProfile(FanProfileRequestDto requestDto);
+
 }

--- a/backend/src/main/java/com/footalentgroup/services/FanProfileService.java
+++ b/backend/src/main/java/com/footalentgroup/services/FanProfileService.java
@@ -1,0 +1,13 @@
+package com.footalentgroup.services;
+
+import com.footalentgroup.models.dtos.request.FanProfileRequestDto;
+import com.footalentgroup.models.dtos.response.FanProfileResponseDto;
+import com.footalentgroup.models.entities.UserEntity;
+
+public interface FanProfileService {
+    FanProfileResponseDto getFanProfileById(Long id);
+
+    void createFanProfile(UserEntity user);
+
+    void updateFanProfile(FanProfileRequestDto requestDto);
+}

--- a/backend/src/main/java/com/footalentgroup/services/impl/AuthServiceImpl.java
+++ b/backend/src/main/java/com/footalentgroup/services/impl/AuthServiceImpl.java
@@ -7,6 +7,7 @@ import com.footalentgroup.models.entities.UserEntity;
 import com.footalentgroup.models.enums.Role;
 import com.footalentgroup.repositories.UserRepository;
 import com.footalentgroup.services.AuthService;
+import com.footalentgroup.services.FanProfileService;
 import com.footalentgroup.services.JwtService;
 import com.footalentgroup.services.MusicianProfileService;
 import jakarta.servlet.http.HttpServletResponse;
@@ -23,6 +24,7 @@ public class AuthServiceImpl implements AuthService {
     private final JwtService jwtService;
     private final PasswordEncoder passwordEncoder;
     private final MusicianProfileService musicService;
+    private final FanProfileService fanService;
 
     @Override
     @Transactional
@@ -32,6 +34,8 @@ public class AuthServiceImpl implements AuthService {
 
         if (Role.MUSICIAN.equals(user.getRole())) {
             musicService.createProfile(savedUser);
+        }else if (Role.FAN.equals(user.getRole())) {
+            fanService.createFanProfile(savedUser);
         }
 
         return generateToken(user, response);

--- a/backend/src/main/java/com/footalentgroup/services/impl/FanProfileServiceImp.java
+++ b/backend/src/main/java/com/footalentgroup/services/impl/FanProfileServiceImp.java
@@ -54,11 +54,7 @@ public class FanProfileServiceImp implements FanProfileService {
 
     private void updateGenresIfNeeded(FanProfileRequestDto request, FanProfileEntity fan) {
         if (request.genreInterest() != null && !request.genreInterest().isEmpty()) {
-            // Usamos un Set para eliminar géneros duplicados de la lista de entrada
-            Set<String> uniqueGenres = new HashSet<>(request.genreInterest());
-
-            // Agregar los géneros únicos a la lista de géneros del perfil del fan
-            for (String genre : uniqueGenres) {
+            for (String genre : request.genreInterest()) {
                 if (!fan.getGenreInterest().contains(genre)) {
                     fan.getGenreInterest().add(genre);
                 }

--- a/backend/src/main/java/com/footalentgroup/services/impl/FanProfileServiceImp.java
+++ b/backend/src/main/java/com/footalentgroup/services/impl/FanProfileServiceImp.java
@@ -2,10 +2,18 @@ package com.footalentgroup.services.impl;
 
 import com.footalentgroup.models.dtos.request.FanProfileRequestDto;
 import com.footalentgroup.models.dtos.response.FanProfileResponseDto;
+import com.footalentgroup.models.entities.FanProfileEntity;
 import com.footalentgroup.models.entities.UserEntity;
+import com.footalentgroup.repositories.FanProfileRepository;
 import com.footalentgroup.services.FanProfileService;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
 
-public class FanProfileServiceImp  implements FanProfileService {
+@AllArgsConstructor
+@Service
+public class FanProfileServiceImp implements FanProfileService {
+    private final FanProfileRepository fanProfileRepository;
+
     @Override
     public FanProfileResponseDto getFanProfileById(Long id) {
         return null;
@@ -13,7 +21,9 @@ public class FanProfileServiceImp  implements FanProfileService {
 
     @Override
     public void createFanProfile(UserEntity user) {
-
+        FanProfileEntity fan = new FanProfileEntity();
+        fan.setUser(user);
+        fanProfileRepository.save(fan);
     }
 
     @Override

--- a/backend/src/main/java/com/footalentgroup/services/impl/FanProfileServiceImp.java
+++ b/backend/src/main/java/com/footalentgroup/services/impl/FanProfileServiceImp.java
@@ -1,0 +1,23 @@
+package com.footalentgroup.services.impl;
+
+import com.footalentgroup.models.dtos.request.FanProfileRequestDto;
+import com.footalentgroup.models.dtos.response.FanProfileResponseDto;
+import com.footalentgroup.models.entities.UserEntity;
+import com.footalentgroup.services.FanProfileService;
+
+public class FanProfileServiceImp  implements FanProfileService {
+    @Override
+    public FanProfileResponseDto getFanProfileById(Long id) {
+        return null;
+    }
+
+    @Override
+    public void createFanProfile(UserEntity user) {
+
+    }
+
+    @Override
+    public void updateFanProfile(FanProfileRequestDto requestDto) {
+
+    }
+}


### PR DESCRIPTION
Este pull request implementa la funcionalidad para gestionar el perfil de un fan:

- Se agregaron los endpoints GET /fan-profile/{id} y PUT /fan-profile para obtener y actualizar el perfil de un fan.
- Se implementaron excepciones personalizadas.
- Se crearon los DTOs  para gestionar los datos del perfil.
- Se creó la entidad FanProfileEntity y el repositorio FanProfileRepository para la persistencia de datos.
- Se añadió lógica en el servicio para actualizar el perfil perfil, con validación de usuario autenticado.