### PR TITLE
 Back HU-P6 Implementar funcionalidad para gestionar músicos favoritos

### DIFF
--- a/backend/src/main/java/com/footalentgroup/configuration/SecurityConfig.java
+++ b/backend/src/main/java/com/footalentgroup/configuration/SecurityConfig.java
@@ -74,6 +74,7 @@ public class SecurityConfig {
                                 "/events/search",
                                 "/events/musician/{musicianId}"
                         ).permitAll()
+                        .requestMatchers("/follows/**").authenticated()
                         .requestMatchers(HttpMethod.POST, "/songs").hasRole(Role.MUSICIAN.name())
                         .requestMatchers(HttpMethod.PUT, "/songs/{id}").hasRole(Role.MUSICIAN.name())
                         .requestMatchers(HttpMethod.PUT, "/musician-profile").hasRole(Role.MUSICIAN.name())

--- a/backend/src/main/java/com/footalentgroup/controllers/MusicianFollowsController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/MusicianFollowsController.java
@@ -1,0 +1,52 @@
+package com.footalentgroup.controllers;
+
+import com.footalentgroup.models.dtos.response.ApiResponse;
+import com.footalentgroup.models.entities.MusicianFollowsEntity;
+import com.footalentgroup.services.MusicianFollowsService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Favoritos")
+@RequestMapping(MusicianFollowsController.FOLLOWS)
+public class MusicianFollowsController {
+    public static final String FOLLOWS = "/follows";
+    private final MusicianFollowsService musicianFollowsService;
+
+    @PreAuthorize("hasRole('FAN')")
+    @GetMapping("/fan/{fanId}")
+    public ResponseEntity<?> getFollowedMusicians(@PathVariable Long fanId) {
+        return ResponseEntity
+                .ok()
+                .body(new ApiResponse<>(this.musicianFollowsService.getFollowMusicians(fanId)));
+    }
+
+    @PreAuthorize("hasRole('MUSICIAN')")
+    @GetMapping("/musician/{musicianId}")
+    public ResponseEntity<?> getFansOfMusician(@PathVariable Long musicianId) {
+        return ResponseEntity
+                .ok()
+                .body(new ApiResponse<>(this.musicianFollowsService.getFansByMusician(musicianId)));
+    }
+
+    @PreAuthorize("hasRole('FAN')")
+    @PostMapping("/fan/{fanId}/musician/{musicianId}")
+    public ResponseEntity<?> addMusicianToFavorites(@PathVariable Long fanId, @PathVariable Long musicianId) {
+        this.musicianFollowsService.addMusicianToFavorites(fanId, musicianId);
+        return ResponseEntity.ok().body(new ApiResponse<>("Se agrego el musico correctamente a favoritos"));
+    }
+
+    // Endpoint para eliminar un músico de los favoritos de un fan
+    @PreAuthorize("hasRole('FAN')")
+    @DeleteMapping("/fan/{fanId}/musician/{musicianId}")
+    public  ResponseEntity<?> removeMusicianFromFavorites(@PathVariable Long fanId, @PathVariable Long musicianId) {
+        this.musicianFollowsService.removeMusicianFromFavorites(fanId, musicianId);
+        return ResponseEntity.ok().body(new ApiResponse<>("Se elimino el musico correctamente a favoritos"));
+    }
+}

--- a/backend/src/main/java/com/footalentgroup/controllers/MusicianFollowsController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/MusicianFollowsController.java
@@ -1,7 +1,6 @@
 package com.footalentgroup.controllers;
 
 import com.footalentgroup.models.dtos.response.ApiResponse;
-import com.footalentgroup.models.entities.MusicianFollowsEntity;
 import com.footalentgroup.services.MusicianFollowsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -11,7 +10,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,7 +29,9 @@ public class MusicianFollowsController {
     }
 
     @PreAuthorize("hasRole('MUSICIAN')")
-    @Operation(summary = "Obtiene los fans que siguen a un músico autenticado", security = @SecurityRequirement(name = "bearer-key"))
+    @Operation(summary = "Obtiene los fans que siguen a un músico autenticado",
+            description = "Este endpoint devuelve los fans que siguen al usuario autenticado con rol MUSICIAN. No se requiere ID, ya que la autenticación se utiliza para identificar al músico.",
+            security = @SecurityRequirement(name = "bearer-key"))
     @GetMapping("/musician")
     public ResponseEntity<?> getFansOfMusician() {
         return ResponseEntity
@@ -40,7 +40,9 @@ public class MusicianFollowsController {
     }
 
     @PreAuthorize("hasRole('FAN')")
-    @Operation(summary = "Elimina un músico de los favoritos del fan autenticado", security = @SecurityRequirement(name = "bearer-key"))
+    @Operation(summary = "Agrega un músico de los favoritos del fan autenticado",
+            description = "Este endpoint devuelve los musicos seguidos por el usuario autenticado con rol FAN. No se requiere ID, ya que la autenticación se utiliza para identificar al fan.",
+            security = @SecurityRequirement(name = "bearer-key"))
     @PostMapping("/follow-musician/{musicianId}")
     public ResponseEntity<?> addMusicianToFavorites( @PathVariable Long musicianId) {
         this.musicianFollowsService.addMusicianToFavorites(musicianId);
@@ -49,7 +51,7 @@ public class MusicianFollowsController {
 
     // Endpoint para eliminar un músico de los favoritos de un fan
     @PreAuthorize("hasRole('FAN')")
-    @Operation(summary = "Elimina musico de favoritos de fan autenticado", security = @SecurityRequirement(name = "bearer-key"))
+    @Operation(summary = "Elimina musico de favoritos de fan autenticado (eliminación lógica)", security = @SecurityRequirement(name = "bearer-key"))
     @DeleteMapping("/unfollow-musician/{musicianId}")
     public  ResponseEntity<?> removeMusicianFromFavorites(@PathVariable Long musicianId) {
         this.musicianFollowsService.removeMusicianFromFavorites(musicianId);

--- a/backend/src/main/java/com/footalentgroup/controllers/MusicianFollowsController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/MusicianFollowsController.java
@@ -3,6 +3,8 @@ package com.footalentgroup.controllers;
 import com.footalentgroup.models.dtos.response.ApiResponse;
 import com.footalentgroup.models.entities.MusicianFollowsEntity;
 import com.footalentgroup.services.MusicianFollowsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,33 +22,37 @@ public class MusicianFollowsController {
     private final MusicianFollowsService musicianFollowsService;
 
     @PreAuthorize("hasRole('FAN')")
-    @GetMapping("/fan/{fanId}")
-    public ResponseEntity<?> getFollowedMusicians(@PathVariable Long fanId) {
+    @Operation(summary = "Obtiene los musicos seguidos de un fan autenticado", security = @SecurityRequirement(name = "bearer-key"))
+    @GetMapping("/fan")
+    public ResponseEntity<?> getFollowedMusicians() {
         return ResponseEntity
                 .ok()
-                .body(new ApiResponse<>(this.musicianFollowsService.getFollowMusicians(fanId)));
+                .body(new ApiResponse<>(this.musicianFollowsService.getFollowMusicians()));
     }
 
     @PreAuthorize("hasRole('MUSICIAN')")
-    @GetMapping("/musician/{musicianId}")
-    public ResponseEntity<?> getFansOfMusician(@PathVariable Long musicianId) {
+    @Operation(summary = "Obtiene los fans que siguen a un músico autenticado", security = @SecurityRequirement(name = "bearer-key"))
+    @GetMapping("/musician")
+    public ResponseEntity<?> getFansOfMusician() {
         return ResponseEntity
                 .ok()
-                .body(new ApiResponse<>(this.musicianFollowsService.getFansByMusician(musicianId)));
+                .body(new ApiResponse<>(this.musicianFollowsService.getFansByMusician()));
     }
 
     @PreAuthorize("hasRole('FAN')")
-    @PostMapping("/fan/{fanId}/musician/{musicianId}")
-    public ResponseEntity<?> addMusicianToFavorites(@PathVariable Long fanId, @PathVariable Long musicianId) {
-        this.musicianFollowsService.addMusicianToFavorites(fanId, musicianId);
+    @Operation(summary = "Elimina un músico de los favoritos del fan autenticado", security = @SecurityRequirement(name = "bearer-key"))
+    @PostMapping("/follow-musician/{musicianId}")
+    public ResponseEntity<?> addMusicianToFavorites( @PathVariable Long musicianId) {
+        this.musicianFollowsService.addMusicianToFavorites(musicianId);
         return ResponseEntity.ok().body(new ApiResponse<>("Se agrego el musico correctamente a favoritos"));
     }
 
     // Endpoint para eliminar un músico de los favoritos de un fan
     @PreAuthorize("hasRole('FAN')")
-    @DeleteMapping("/fan/{fanId}/musician/{musicianId}")
-    public  ResponseEntity<?> removeMusicianFromFavorites(@PathVariable Long fanId, @PathVariable Long musicianId) {
-        this.musicianFollowsService.removeMusicianFromFavorites(fanId, musicianId);
+    @Operation(summary = "Elimina musico de favoritos de fan autenticado", security = @SecurityRequirement(name = "bearer-key"))
+    @DeleteMapping("/unfollow-musician/{musicianId}")
+    public  ResponseEntity<?> removeMusicianFromFavorites(@PathVariable Long musicianId) {
+        this.musicianFollowsService.removeMusicianFromFavorites(musicianId);
         return ResponseEntity.ok().body(new ApiResponse<>("Se elimino el musico correctamente a favoritos"));
     }
 }

--- a/backend/src/main/java/com/footalentgroup/exceptions/AlreadyFollowingMusicianException.java
+++ b/backend/src/main/java/com/footalentgroup/exceptions/AlreadyFollowingMusicianException.java
@@ -1,0 +1,7 @@
+package com.footalentgroup.exceptions;
+
+public class AlreadyFollowingMusicianException extends RuntimeException {
+    public AlreadyFollowingMusicianException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/footalentgroup/exceptions/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/footalentgroup/exceptions/GlobalExceptionHandler.java
@@ -110,4 +110,14 @@ public class GlobalExceptionHandler {
                 HttpStatus.NOT_FOUND.value()
         );
     }
+
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @ExceptionHandler(AlreadyFollowingMusicianException.class)
+    public ErrorResponse alreadyFollowingMusician (AlreadyFollowingMusicianException ex) {
+        return new ErrorResponse(
+                "AlreadyFollowingMusicianException",
+                ex.getMessage(),
+                HttpStatus.CONFLICT.value()
+        );
+    }
 }

--- a/backend/src/main/java/com/footalentgroup/models/dtos/mapper/MusicProfileMapper.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/mapper/MusicProfileMapper.java
@@ -3,6 +3,7 @@ package com.footalentgroup.models.dtos.mapper;
 import com.footalentgroup.models.dtos.request.BannerUploadReqestDto;
 import com.footalentgroup.models.dtos.request.MusicianProfileRequestDto;
 import com.footalentgroup.models.dtos.response.MusicianProfileResponseDto;
+import com.footalentgroup.models.dtos.response.MusicianSimpleResponseDto;
 import com.footalentgroup.models.entities.MusicianProfileEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -16,6 +17,9 @@ public interface MusicProfileMapper{
 
     @Mapping(source = "photoUrl", target = "photoUrl")
     MusicianProfileResponseDto toResponse(MusicianProfileEntity entity);
+
+    @Mapping(source = "photoUrl", target = "photoUrl")
+    MusicianSimpleResponseDto toSimpleResponse(MusicianProfileEntity entity);
 
     @Mapping(target = "photoUrl", ignore = true)
     void updateEntity(MusicianProfileRequestDto dto, @MappingTarget MusicianProfileEntity entity);

--- a/backend/src/main/java/com/footalentgroup/models/dtos/response/MusicianSimpleResponseDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/response/MusicianSimpleResponseDto.java
@@ -1,0 +1,10 @@
+package com.footalentgroup.models.dtos.response;
+
+public record MusicianSimpleResponseDto(
+        String stageName,
+        String photoUrl,
+        String genre,
+        String country
+)
+{
+}

--- a/backend/src/main/java/com/footalentgroup/models/entities/FanProfileEntity.java
+++ b/backend/src/main/java/com/footalentgroup/models/entities/FanProfileEntity.java
@@ -1,9 +1,11 @@
 package com.footalentgroup.models.entities;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -30,4 +32,9 @@ public class FanProfileEntity {
     @MapsId
     @JoinColumn(name = "id")
     private UserEntity user;
+
+    @ToString.Exclude
+    @JsonIgnore
+    @OneToMany(mappedBy = "fan",  fetch = FetchType.LAZY)
+    private List<MusicianFollowsEntity> followedMusicians;
 }

--- a/backend/src/main/java/com/footalentgroup/models/entities/FanProfileEntity.java
+++ b/backend/src/main/java/com/footalentgroup/models/entities/FanProfileEntity.java
@@ -33,8 +33,4 @@ public class FanProfileEntity {
     @JoinColumn(name = "id")
     private UserEntity user;
 
-    @ToString.Exclude
-    @JsonIgnore
-    @OneToMany(mappedBy = "fan",  fetch = FetchType.LAZY)
-    private List<MusicianFollowsEntity> followedMusicians;
 }

--- a/backend/src/main/java/com/footalentgroup/models/entities/MusicianFollowsEntity.java
+++ b/backend/src/main/java/com/footalentgroup/models/entities/MusicianFollowsEntity.java
@@ -5,7 +5,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
-import java.time.LocalDate;
 import java.time.OffsetDateTime;
 
 @Entity
@@ -24,10 +23,10 @@ public class MusicianFollowsEntity {
     private OffsetDateTime created_at;
 
     @ManyToOne
-    @JoinColumn(name = "musician_id", nullable = false)
+    @JoinColumn(name = "musician", nullable = false)
     private MusicianProfileEntity musician;
 
     @ManyToOne
-    @JoinColumn(name = "fan_id", nullable = false)
+    @JoinColumn(name = "fan", nullable = false)
     private FanProfileEntity fan;
 }

--- a/backend/src/main/java/com/footalentgroup/models/entities/MusicianFollowsEntity.java
+++ b/backend/src/main/java/com/footalentgroup/models/entities/MusicianFollowsEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.OffsetDateTime;
 
@@ -21,6 +22,13 @@ public class MusicianFollowsEntity {
     @CreationTimestamp
     @Column(updatable = false)
     private OffsetDateTime created_at;
+
+    @Column(name = "deleted_at", nullable = true)
+    private OffsetDateTime deletedAt;
+
+    @UpdateTimestamp
+    @Column(insertable = false)
+    private OffsetDateTime updatedAt;
 
     @ManyToOne
     @JoinColumn(name = "musician", nullable = false)

--- a/backend/src/main/java/com/footalentgroup/models/entities/MusicianFollowsEntity.java
+++ b/backend/src/main/java/com/footalentgroup/models/entities/MusicianFollowsEntity.java
@@ -1,0 +1,33 @@
+package com.footalentgroup.models.entities;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+@Entity
+@Data
+@NoArgsConstructor
+@Table(name = "musician_follows", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"musician_id", "fan_id"})
+})
+public class MusicianFollowsEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @CreationTimestamp
+    @Column(updatable = false)
+    private OffsetDateTime created_at;
+
+    @ManyToOne
+    @JoinColumn(name = "musician_id", nullable = false)
+    private MusicianProfileEntity musician;
+
+    @ManyToOne
+    @JoinColumn(name = "fan_id", nullable = false)
+    private FanProfileEntity fan;
+}

--- a/backend/src/main/java/com/footalentgroup/models/entities/MusicianFollowsEntity.java
+++ b/backend/src/main/java/com/footalentgroup/models/entities/MusicianFollowsEntity.java
@@ -18,7 +18,7 @@ public class MusicianFollowsEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    
+
     @CreationTimestamp
     @Column(updatable = false)
     private OffsetDateTime created_at;

--- a/backend/src/main/java/com/footalentgroup/models/entities/MusicianProfileEntity.java
+++ b/backend/src/main/java/com/footalentgroup/models/entities/MusicianProfileEntity.java
@@ -43,8 +43,4 @@ public class MusicianProfileEntity {
     @OneToMany(mappedBy = "musicianProfile", fetch = FetchType.LAZY)
     private List<SongEntity> songs;
 
-    @ToString.Exclude
-    @JsonIgnore
-    @OneToMany(mappedBy = "fan", fetch = FetchType.LAZY)
-    private List<MusicianFollowsEntity> followers;
 }

--- a/backend/src/main/java/com/footalentgroup/models/entities/MusicianProfileEntity.java
+++ b/backend/src/main/java/com/footalentgroup/models/entities/MusicianProfileEntity.java
@@ -1,8 +1,10 @@
 package com.footalentgroup.models.entities;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -41,4 +43,8 @@ public class MusicianProfileEntity {
     @OneToMany(mappedBy = "musicianProfile", fetch = FetchType.LAZY)
     private List<SongEntity> songs;
 
+    @ToString.Exclude
+    @JsonIgnore
+    @OneToMany(mappedBy = "fan",  fetch = FetchType.LAZY)
+    private List<MusicianFollowsEntity> followedMusicians;
 }

--- a/backend/src/main/java/com/footalentgroup/models/entities/MusicianProfileEntity.java
+++ b/backend/src/main/java/com/footalentgroup/models/entities/MusicianProfileEntity.java
@@ -45,6 +45,6 @@ public class MusicianProfileEntity {
 
     @ToString.Exclude
     @JsonIgnore
-    @OneToMany(mappedBy = "fan",  fetch = FetchType.LAZY)
-    private List<MusicianFollowsEntity> followedMusicians;
+    @OneToMany(mappedBy = "fan", fetch = FetchType.LAZY)
+    private List<MusicianFollowsEntity> followers;
 }

--- a/backend/src/main/java/com/footalentgroup/repositories/MusicianFollowsRepository.java
+++ b/backend/src/main/java/com/footalentgroup/repositories/MusicianFollowsRepository.java
@@ -1,0 +1,24 @@
+package com.footalentgroup.repositories;
+
+import com.footalentgroup.models.dtos.response.FanProfileResponseDto;
+import com.footalentgroup.models.dtos.response.MusicianInfoReponseDto;
+import com.footalentgroup.models.dtos.response.MusicianProfileResponseDto;
+import com.footalentgroup.models.entities.MusicianFollowsEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MusicianFollowsRepository extends JpaRepository<MusicianFollowsEntity, Long> {
+
+    List<MusicianInfoReponseDto> findByFanId(Long fanId);
+
+
+    List<FanProfileResponseDto> findByMusicianId(Long musicianId);
+
+    // Verificar si un fan ya sigue a un músico
+    boolean existsByFanIdAndMusicianId(Long fanId, Long musicianId);
+
+    MusicianFollowsEntity findByFanIdAndMusicianId(Long fanId, Long musicianId);
+}

--- a/backend/src/main/java/com/footalentgroup/repositories/MusicianFollowsRepository.java
+++ b/backend/src/main/java/com/footalentgroup/repositories/MusicianFollowsRepository.java
@@ -1,21 +1,20 @@
 package com.footalentgroup.repositories;
 
 import com.footalentgroup.models.dtos.response.FanProfileResponseDto;
-import com.footalentgroup.models.dtos.response.MusicianInfoReponseDto;
-import com.footalentgroup.models.dtos.response.MusicianProfileResponseDto;
+import com.footalentgroup.models.entities.FanProfileEntity;
 import com.footalentgroup.models.entities.MusicianFollowsEntity;
+import com.footalentgroup.models.entities.MusicianProfileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
+
 public interface MusicianFollowsRepository extends JpaRepository<MusicianFollowsEntity, Long> {
 
-    List<MusicianInfoReponseDto> findByFanId(Long fanId);
+    List<MusicianProfileEntity> findByFanId(Long fanId);
 
 
-    List<FanProfileResponseDto> findByMusicianId(Long musicianId);
+    List<FanProfileEntity> findByMusicianId(Long musicianId);
 
     // Verificar si un fan ya sigue a un músico
     boolean existsByFanIdAndMusicianId(Long fanId, Long musicianId);

--- a/backend/src/main/java/com/footalentgroup/repositories/MusicianFollowsRepository.java
+++ b/backend/src/main/java/com/footalentgroup/repositories/MusicianFollowsRepository.java
@@ -11,10 +11,10 @@ import java.util.List;
 
 public interface MusicianFollowsRepository extends JpaRepository<MusicianFollowsEntity, Long> {
 
-    List<MusicianProfileEntity> findByFanId(Long fanId);
+    List<MusicianFollowsEntity> findByFanIdAndDeletedAtIsNull(Long fanId);
 
 
-    List<FanProfileEntity> findByMusicianId(Long musicianId);
+    List<MusicianFollowsEntity> findByMusicianIdAndDeletedAtIsNull(Long musicianId);
 
     // Verificar si un fan ya sigue a un músico
     boolean existsByFanIdAndMusicianId(Long fanId, Long musicianId);

--- a/backend/src/main/java/com/footalentgroup/services/MusicianFollowsService.java
+++ b/backend/src/main/java/com/footalentgroup/services/MusicianFollowsService.java
@@ -1,13 +1,12 @@
 package com.footalentgroup.services;
 
 import com.footalentgroup.models.dtos.response.FanProfileResponseDto;
-import com.footalentgroup.models.dtos.response.MusicianInfoReponseDto;
-import com.footalentgroup.models.dtos.response.MusicianProfileResponseDto;
+import com.footalentgroup.models.dtos.response.MusicianSimpleResponseDto;
 
 import java.util.List;
 
 public interface MusicianFollowsService {
-    public List<MusicianProfileResponseDto> getFollowMusicians ();
+    public List<MusicianSimpleResponseDto> getFollowMusicians ();
 
     public List<FanProfileResponseDto> getFansByMusician ();
 

--- a/backend/src/main/java/com/footalentgroup/services/MusicianFollowsService.java
+++ b/backend/src/main/java/com/footalentgroup/services/MusicianFollowsService.java
@@ -2,15 +2,16 @@ package com.footalentgroup.services;
 
 import com.footalentgroup.models.dtos.response.FanProfileResponseDto;
 import com.footalentgroup.models.dtos.response.MusicianInfoReponseDto;
+import com.footalentgroup.models.dtos.response.MusicianProfileResponseDto;
 
 import java.util.List;
 
 public interface MusicianFollowsService {
-    public List<MusicianInfoReponseDto> getFollowMusicians (Long fan_id);
+    public List<MusicianProfileResponseDto> getFollowMusicians ();
 
-    public List<FanProfileResponseDto> getFansByMusician (Long musician_id);
+    public List<FanProfileResponseDto> getFansByMusician ();
 
-    public void addMusicianToFavorites(Long fan_id, Long musician_id);
+    public void addMusicianToFavorites(Long musician_id);
 
-    public void removeMusicianFromFavorites(Long fanId, Long musicianId);
+    public void removeMusicianFromFavorites(Long musicianId);
 }

--- a/backend/src/main/java/com/footalentgroup/services/MusicianFollowsService.java
+++ b/backend/src/main/java/com/footalentgroup/services/MusicianFollowsService.java
@@ -1,0 +1,16 @@
+package com.footalentgroup.services;
+
+import com.footalentgroup.models.dtos.response.FanProfileResponseDto;
+import com.footalentgroup.models.dtos.response.MusicianInfoReponseDto;
+
+import java.util.List;
+
+public interface MusicianFollowsService {
+    public List<MusicianInfoReponseDto> getFollowMusicians (Long fan_id);
+
+    public List<FanProfileResponseDto> getFansByMusician (Long musician_id);
+
+    public void addMusicianToFavorites(Long fan_id, Long musician_id);
+
+    public void removeMusicianFromFavorites(Long fanId, Long musicianId);
+}

--- a/backend/src/main/java/com/footalentgroup/services/impl/MusicianFollowsServiceImlp.java
+++ b/backend/src/main/java/com/footalentgroup/services/impl/MusicianFollowsServiceImlp.java
@@ -1,0 +1,68 @@
+package com.footalentgroup.services.impl;
+
+import com.footalentgroup.exceptions.AlreadyFollowingMusicianException;
+import com.footalentgroup.exceptions.FanProfileNotFoundException;
+import com.footalentgroup.exceptions.MusicianProfileNotFoundException;
+import com.footalentgroup.models.dtos.response.FanProfileResponseDto;
+import com.footalentgroup.models.dtos.response.MusicianInfoReponseDto;
+import com.footalentgroup.models.entities.FanProfileEntity;
+import com.footalentgroup.models.entities.MusicianFollowsEntity;
+import com.footalentgroup.models.entities.MusicianProfileEntity;
+import com.footalentgroup.repositories.FanProfileRepository;
+import com.footalentgroup.repositories.MusicianFollowsRepository;
+import com.footalentgroup.repositories.MusicianProfileRepository;
+import com.footalentgroup.services.MusicianFollowsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MusicianFollowsServiceImlp implements MusicianFollowsService {
+    private MusicianFollowsRepository musicianFollowsRepository;
+    private FanProfileRepository fanRepository;
+    private MusicianProfileRepository musicianRepository;
+
+    //Obtener musicos seguido por un fan
+    @Override
+    public List<MusicianInfoReponseDto> getFollowMusicians(Long fan_id) {
+        return musicianFollowsRepository.findByFanId(fan_id);
+
+    }
+
+    //Obtener seguidores de musico
+    @Override
+    public List<FanProfileResponseDto> getFansByMusician(Long musician_id) {
+        return musicianFollowsRepository.findByMusicianId(musician_id);
+    }
+
+    @Override
+    public void addMusicianToFavorites(Long fan_id, Long musician_id) {
+      //verificamos si el musico ya se encuentra en favoritos de fan
+        if(!musicianFollowsRepository.existsByFanIdAndMusicianId(fan_id, musician_id)){
+            MusicianFollowsEntity follow = new MusicianFollowsEntity();
+
+            FanProfileEntity fan = fanRepository.findById(fan_id).
+                    orElseThrow(() -> new FanProfileNotFoundException("El perfil de fan con ID" + fan_id + " no existe."));
+
+            MusicianProfileEntity musician = musicianRepository.findById(musician_id)
+                    .orElseThrow(()-> new MusicianProfileNotFoundException("El perfil de musico con ID" + musician_id + " no existe."));
+
+            follow.setFan(fan);
+            follow.setMusician(musician);
+
+            musicianFollowsRepository.save(follow);
+        }else{
+            throw new AlreadyFollowingMusicianException("El fan ya sigue a este músico.");
+        }
+    }
+
+    @Override
+    public void removeMusicianFromFavorites(Long fanId, Long musicianId) {
+        MusicianFollowsEntity follow = musicianFollowsRepository.findByFanIdAndMusicianId(fanId, musicianId);
+        if (follow != null) {
+            musicianFollowsRepository.delete(follow);
+        }
+    }
+}


### PR DESCRIPTION
Este PR incorpora la funcionalidad necesaria  para gestionar músicos favoritos. Entre los cambios principales se incluyen:

-  Implementación del alta y baja lógica de favoritos.
-  Creación  de endpoints para seguir y dejar de seguir músicos.
-  Aplicación de filtrado para devolver solo los favoritos activos.
- Protección de rutas mediante control de acceso por roles.
- Se permite que tanto el fan como el músico autenticados (y con el rol correspondiente) consulten sus músicos seguidos o fans, respectivamente.