### PR TITLE
Agregar sección de datos para donación en el perfil del músico

### DIFF
--- a/frontend/src/profile/components/forms/FormMusicianProfile.tsx
+++ b/frontend/src/profile/components/forms/FormMusicianProfile.tsx
@@ -15,6 +15,7 @@ import { SocialLinksSection } from "./components/sections/SocialLinksSection";
 import ProfilePhotoSection from "./components/sections/ProfilePhotoSection";
 import { useApiMutation } from "@/shared/hooks/use-api-mutation";
 import { PersonalDataMusicianSection } from "./components/sections/PersonalDataMusicianSection";
+import { DonationDataSection } from "./components/sections/DonationDataSection";
 
 interface FormMusicianProfileProps {
   onClose: () => void;
@@ -122,10 +123,16 @@ const FormMusicianProfile = ({ onClose }: FormMusicianProfileProps) => {
         className="order-3 md:order-3 lg:order-3"
       />
 
-      <SocialLinksSection
+      <DonationDataSection
         register={register}
         errors={errors}
         className="order-4 md:order-4 lg:order-4 lg:col-start-1"
+      />
+
+      <SocialLinksSection
+        register={register}
+        errors={errors}
+        className="order-5 md:order-5 lg:order-5 lg:col-start-1"
       />
 
       <div className="containerBtnSectionProfile">

--- a/frontend/src/profile/components/forms/components/labeledFields/LabeledInput.tsx
+++ b/frontend/src/profile/components/forms/components/labeledFields/LabeledInput.tsx
@@ -17,7 +17,7 @@ const LabeledInput = ({ label, htmlFor, className = "", inputProps, error }: Lab
       </label>
       <Input
         {...inputProps}
-        className="w-full rounded-none placeholder:text-sm placeholder:text-black focus:placeholder-transparent"
+        className="placeholder:text-ecos-blue w-full rounded-none placeholder:text-sm focus:placeholder-transparent"
       />
       {error && <span className="w-max text-sm text-red-500">{error}</span>}
     </div>

--- a/frontend/src/profile/components/forms/components/sections/DonationDataSection.tsx
+++ b/frontend/src/profile/components/forms/components/sections/DonationDataSection.tsx
@@ -1,0 +1,53 @@
+import LabeledInput from "../labeledFields/LabeledInput";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { FormMusicianProfileSchema } from "../../shemas/ProfileSchema";
+
+interface DonationDataProps {
+  errors: FieldErrors<FormMusicianProfileSchema>;
+  register: UseFormRegister<FormMusicianProfileSchema>;
+  className?: string;
+}
+
+export const DonationDataSection = ({ errors, register, className }: DonationDataProps) => {
+  return (
+    <fieldset className={`fieldsetSectionProfile ${className ?? ""}`}>
+      <legend className="legendSectionProfile">DATOS PARA DONACIÓN</legend>
+
+      <LabeledInput
+        label="🔗 Link de pago rápido"
+        htmlFor="paymentLink"
+        inputProps={{
+          id: "paymentLink",
+          type: "text",
+          placeholder: "https://ejemplo.com/pago",
+          ...register("paymentLink"),
+        }}
+        error={errors.paymentLink?.message}
+      />
+
+      <LabeledInput
+        label="Alias"
+        htmlFor="paymentAlias"
+        inputProps={{
+          id: "paymentAlias",
+          type: "text",
+          placeholder: "alias.banco-123",
+          ...register("paymentAlias"),
+        }}
+        error={errors.paymentAlias?.message}
+      />
+
+      <LabeledInput
+        label="CBU"
+        htmlFor="cbu"
+        inputProps={{
+          id: "cbu",
+          type: "text",
+          placeholder: "AR1234567890123456789012",
+          ...register("cbu"),
+        }}
+        error={errors.cbu?.message}
+      />
+    </fieldset>
+  );
+};

--- a/frontend/src/profile/components/forms/shemas/ProfileSchema.ts
+++ b/frontend/src/profile/components/forms/shemas/ProfileSchema.ts
@@ -30,7 +30,7 @@ export const formMusicianProfileSchema = baseProfileSchema.extend({
     }),
   genre: z.string().min(1, { message: "El género es obligatorio." }),
   paymentLink: z.string().url({ message: "Debe ser un enlace válido" }).or(z.literal("")),
-  alias: z
+  paymentAlias: z
     .string()
     .regex(aliasRegex, {
       message: "El alias solo puede contener letras, números, puntos y guiones",
@@ -39,7 +39,7 @@ export const formMusicianProfileSchema = baseProfileSchema.extend({
       message: "El alias debe tener entre 6 y 20 caracteres",
     })
     .or(z.literal("")),
-  accountNumber: z
+  cbu: z
     .string()
     .regex(accountNumberRegex, {
       message: "Solo se permiten letras mayúsculas y números (ej. IBAN)",

--- a/frontend/src/profile/hooks/use-load-musician-form.ts
+++ b/frontend/src/profile/hooks/use-load-musician-form.ts
@@ -41,8 +41,8 @@ export function useLoadMusicianForm({
     setGenre(genreLabel);
 
     setValue("paymentLink", data.paymentLink ?? "");
-    setValue("alias", data.alias ?? "");
-    setValue("accountNumber", data.accountNumber ?? "");
+    setValue("paymentAlias", data.paymentAlias ?? "");
+    setValue("cbu", data.cbu ?? "");
 
     setValue("whatsapp", data.whatsapp ?? "");
     setValue("spotifyUrl", data.spotifyUrl ?? "");

--- a/frontend/src/profile/utils/handlers/handle-musician-profile-submit.ts
+++ b/frontend/src/profile/utils/handlers/handle-musician-profile-submit.ts
@@ -29,6 +29,18 @@ export const handleMusicianProfileSubmit = ({
 
   formData.append("deletePhoto", deletePhoto);
 
+  if (data.paymentLink) {
+    formData.append("paymentLink", data.paymentLink);
+  }
+
+  if (data.paymentAlias) {
+    formData.append("paymentAlias", data.paymentAlias);
+  }
+
+  if (data.cbu) {
+    formData.append("cbu", data.cbu);
+  }
+
   if (data.whatsapp) {
     formData.append("whatsapp", data.whatsapp);
   }


### PR DESCRIPTION
**Agregar sección de datos para donación en el perfil del músico**

Implementación de la sección de Datos para Donación en el formulario del perfil del músico.
Cambios realizados:

- Se modificó el esquema FormMusicianProfileSchema: alias  y accountNumber por paymentAlias y cbu, respectivamente. 
- Se actualizó el hook use-load-musician para mapear los nuevos nombres de campos.
- Se creó la sección DonationDataSection, que incluye inputs para enlace de pago (paymentLink), alias (paymentAlias) y CBU (cbu).
- Se extendió handleMusicianProfileSubmit para enviar los datos mencionados.
- Se integró DonationDataSection en el componente FormMusicianProfile.