### PR TITLE
feat(backend): implement search endpoint by title or genre with pagination

### DIFF
--- a/backend/src/main/java/com/footalentgroup/controllers/SongController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/SongController.java
@@ -57,6 +57,13 @@ public class SongController {
         return ResponseEntity.ok().body(songService.getAllSongsByMusicianId(id,pageable));
     }
 
+    @GetMapping("/search")
+    @Operation(summary = "Obtiene una lista paginada de canciones cuyo título o género contenga el término de búsqueda especificado.")
+    public ResponseEntity<?> searchSongs(@RequestParam(value = "search", required = false) String search, @ParameterObject @Valid SongPageRequestDto request) {
+        Pageable pageable = PageRequest.of(request.getPage(), request.getSize(), request.getSort());
+        return ResponseEntity.ok().body(songService.searchSongs(search,pageable));
+    }
+
     @PutMapping(value = "/{id}", consumes = "multipart/form-data")
     @Operation(summary = "Actualiza una canción por ID (requiere autenticación, solo el autor puede editar)", security = @SecurityRequirement(name = "bearer-key"))
     public ResponseEntity<?> updateSong(@PathVariable Long id, @ModelAttribute @Valid SongUploadRequestDto request) {

--- a/backend/src/main/java/com/footalentgroup/models/dtos/request/BannerUploadReqestDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/request/BannerUploadReqestDto.java
@@ -8,7 +8,7 @@ public record BannerUploadReqestDto(
         @ImageFile
         MultipartFile banner,
 
-        @Schema(description = "Campo para indicar que se desea eliminar el banner", defaultValue = "false")
+        @Schema(description = "Campo para indicar que se desea eliminar el banner", defaultValue = "false", required = true)
         boolean deleteBanner
 ) {
 }

--- a/backend/src/main/java/com/footalentgroup/models/dtos/request/SongPageRequestDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/request/SongPageRequestDto.java
@@ -23,7 +23,7 @@ public class SongPageRequestDto {
     @Parameter(description = "Tamaño de página", example = "10")
     private int size = 10;
 
-    @Pattern(regexp = "title|artist", message = "El campo de ordenamiento no es válido")
+    @Pattern(regexp = "title|genre", message = "El campo de ordenamiento no es válido")
     @Parameter(description = "Campo por el que ordenar", example = "title")
     private String sortBy = "title";
 

--- a/backend/src/main/java/com/footalentgroup/repositories/SongRepository.java
+++ b/backend/src/main/java/com/footalentgroup/repositories/SongRepository.java
@@ -14,4 +14,7 @@ public interface SongRepository extends JpaRepository<SongEntity,Long> {
     Optional<SongEntity> findByIdAndMusicianProfile_User_Email(Long idSong, String email);
 
     Page<SongEntity> findByMusicianProfileId(Long idMusician, Pageable pageable);
+
+    Page<SongEntity> findByTitleContainingIgnoreCaseOrGenreContainingIgnoreCase(String title, String genre, Pageable pageable);
+
 }

--- a/backend/src/main/java/com/footalentgroup/services/SongService.java
+++ b/backend/src/main/java/com/footalentgroup/services/SongService.java
@@ -17,7 +17,10 @@ public interface SongService {
 
     PageResponseDto<SongResponseDto> getAllSongsByMusicianId(Long idMusician, Pageable pageable);
 
+    PageResponseDto<SongResponseDto> searchSongs(String search, Pageable pageable);
+
     void deleteSong(Long id);
+
 
 
 }

--- a/backend/src/main/java/com/footalentgroup/services/impl/SongServiceImpl.java
+++ b/backend/src/main/java/com/footalentgroup/services/impl/SongServiceImpl.java
@@ -14,6 +14,7 @@ import com.footalentgroup.services.AuthenticatedUserService;
 import com.footalentgroup.services.CloudinaryService;
 import com.footalentgroup.services.SongService;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -108,6 +109,16 @@ public class SongServiceImpl implements SongService {
     @Override
     public PageResponseDto<SongResponseDto> getAllSongsByMusicianId(Long idMusician, Pageable pageable) {
         Page<SongEntity> songPage = songRepository.findByMusicianProfileId(idMusician,pageable);
+        return mapper.toPageResponse(songPage);
+    }
+
+    @Override
+    public PageResponseDto<SongResponseDto> searchSongs(String search, Pageable pageable) {
+        Page<SongEntity> songPage =
+                StringUtils.isBlank(search)
+                        ? songRepository.findAll(pageable)
+                        : songRepository.findByTitleContainingIgnoreCaseOrGenreContainingIgnoreCase(search, search, pageable);
+
         return mapper.toPageResponse(songPage);
     }
 


### PR DESCRIPTION
Added a new GET /songs/search endpoint that allows users to search songs by title or genre using a single input field. The search supports partial matches and is fully paginated using Pageable. If no search term is provided, it returns all songs.