### PR TITLE
Add @PreAuthorize annotations for role-based access control

### DIFF
--- a/backend/src/main/java/com/footalentgroup/configuration/SecurityConfig.java
+++ b/backend/src/main/java/com/footalentgroup/configuration/SecurityConfig.java
@@ -1,7 +1,6 @@
 package com.footalentgroup.configuration;
 
 import com.footalentgroup.models.entities.UserEntity;
-import com.footalentgroup.models.enums.Role;
 import com.footalentgroup.repositories.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -88,12 +87,7 @@ public class SecurityConfig {
                                 "/events/search",
                                 "/events/musician/{musicianId}"
                         ).permitAll()
-                        .requestMatchers("/follows/**").authenticated()
-                        .requestMatchers(HttpMethod.POST, "/songs").hasRole(Role.MUSICIAN.name())
-                        .requestMatchers(HttpMethod.PUT, "/songs/{id}").hasRole(Role.MUSICIAN.name())
-                        .requestMatchers(HttpMethod.GET, "/saved-songs").hasRole(Role.FAN.name())
-                        .requestMatchers(HttpMethod.POST, "/saved-songs/save/{song_id}").hasRole(Role.FAN.name())
-                        .requestMatchers(HttpMethod.DELETE, "/saved-songs/remove/{song_id}").hasRole(Role.FAN.name())
+
                         .anyRequest().authenticated()
                 )
                 .authenticationProvider(authenticationProvider())

--- a/backend/src/main/java/com/footalentgroup/controllers/FanProfileController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/FanProfileController.java
@@ -9,14 +9,16 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping(FanProfileController.FAN)
+@RequestMapping(FanProfileController.FANS)
 @RequiredArgsConstructor
-@Tag(name = "Fan Profile")
+@Tag(name = "Perfil de Fan")
 public class FanProfileController {
-    public static final String FAN = "/fan-profile";
+    public static final String FANS = "/fan-profile";
+
     private final FanProfileService fanProfileService;
 
     @Operation(summary = "Obtiene perfil del fan especificado por id")
@@ -29,6 +31,7 @@ public class FanProfileController {
 
     @Operation(summary = "Actualiza perfil del fan, solo usuario autenticado", security = @SecurityRequirement(name = "bearer-key"))
     @PutMapping(consumes = "multipart/form-data")
+    @PreAuthorize("hasRole('FAN')")
     public ResponseEntity<?> updateFanProfile(@ModelAttribute @Valid FanProfileRequestDto requestDto){
         this.fanProfileService.updateFanProfile(requestDto);
         return ResponseEntity

--- a/backend/src/main/java/com/footalentgroup/controllers/MusicianProfileController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/MusicianProfileController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping(MusicianProfileController.MUSICIANS)
 @RequiredArgsConstructor
-@Tag(name = "Musician Profile")
+@Tag(name = "Perfil de Músico")
 public class MusicianProfileController {
     public static final String MUSICIANS = "/musician-profile";
     public static final String ID_ID = "/{id}";

--- a/backend/src/main/java/com/footalentgroup/controllers/SavedSongController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/SavedSongController.java
@@ -1,6 +1,5 @@
 package com.footalentgroup.controllers;
 
-
 import com.footalentgroup.models.dtos.request.SongPageRequestDto;
 import com.footalentgroup.models.dtos.response.ApiResponse;
 import com.footalentgroup.services.SavedSongService;
@@ -18,27 +17,29 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping(SavedSongController.PATH)
+@RequestMapping(SavedSongController.SAVED_SONGS)
 @RequiredArgsConstructor
-@Tag(name = "Saved Songs")
+@Tag(name = "Guardar Canciones")
 public class SavedSongController {
-    public static final String  PATH = "/saved-songs";
+    public static final String SAVED_SONGS = "/saved-songs";
+
     private final SavedSongService savedSongService;
 
-
-    @GetMapping()
     @Operation(summary = "Obtiene todas las canciones guardadas de fan autenticado",
             description = "Los datos del fan se obtienen del token de autenticación.",
             security = @SecurityRequirement(name = "bearer-key"))
+    @GetMapping
+    @PreAuthorize("hasRole('FAN')")
     public ResponseEntity<?> getAllSongs(@Valid @ParameterObject SongPageRequestDto request) {
         Pageable pageable = PageRequest.of(request.getPage(), request.getSize(), request.getSort());
         return ResponseEntity.ok().body(savedSongService.getSavedSongsByFan(pageable));
     }
 
-    @PostMapping("/save/{song_id}")
     @Operation(summary = "Guarda una cancion en favoritos de fan autenticado",
             description = "Los datos del fan se obtienen del token de autenticación.",
             security = @SecurityRequirement(name = "bearer-key"))
+    @PostMapping("/save/{song_id}")
+    @PreAuthorize("hasRole('FAN')")
     public ResponseEntity<?> saveSongAsFavourite(@PathVariable Long song_id) {
         savedSongService.saveSongAsFavourite(song_id);
         return ResponseEntity
@@ -46,10 +47,11 @@ public class SavedSongController {
                 .body(new ApiResponse<>("Canción guardada con exito"));
     }
 
-    @DeleteMapping("/remove/{song_id}")
     @Operation(summary = "Elimina una cancion en favoritos de fan autenticado (eliminacion logica)",
             description = "Los datos del fan se obtienen del token de autenticación.",
             security = @SecurityRequirement(name = "bearer-key"))
+    @DeleteMapping("/remove/{song_id}")
+    @PreAuthorize("hasRole('FAN')")
     public ResponseEntity<?> deleteSongFromFavourites(@PathVariable Long song_id) {
         savedSongService.deleteSongFromFavourites(song_id);
         return ResponseEntity

--- a/backend/src/main/java/com/footalentgroup/controllers/SongController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/SongController.java
@@ -1,6 +1,5 @@
 package com.footalentgroup.controllers;
 
-
 import com.footalentgroup.models.dtos.request.SongPageRequestDto;
 import com.footalentgroup.models.dtos.request.SongUploadRequestDto;
 import com.footalentgroup.models.dtos.response.ApiResponse;
@@ -13,23 +12,23 @@ import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping(SongController.SONG)
+@RequestMapping(SongController.SONGS)
 @RequiredArgsConstructor
-@Tag(name = "Musica")
+@Tag(name = "Canciones")
 public class SongController {
-
-    public static final String SONG = "/songs";
+    public static final String SONGS = "/songs";
 
     private final SongService songService;
 
-    @PostMapping(consumes = "multipart/form-data")
     @Operation(summary = "Sube una nueva canción (requiere autenticación)", security = @SecurityRequirement(name = "bearer-key"))
+    @PostMapping(consumes = "multipart/form-data")
+    @PreAuthorize("hasRole('MUSICIAN')")
     public ResponseEntity<?> uploadSong(@ModelAttribute @Valid SongUploadRequestDto request) {
         songService.uploadSong(request);
         return ResponseEntity
@@ -37,44 +36,38 @@ public class SongController {
                 .body(new ApiResponse<>("Canción subida con exito"));
     }
 
-    @GetMapping("/{id}")
     @Operation(summary = "Obtiene una canción por su ID")
+    @GetMapping("/{id}")
     public ResponseEntity<?> getSongById(@PathVariable Long id) {
         return ResponseEntity.ok().body(songService.getSongById(id));
     }
 
-    @GetMapping
     @Operation(summary = "Obtiene todas las canciones")
+    @GetMapping
     public ResponseEntity<?> getAllSongs(@Valid @ParameterObject SongPageRequestDto request) {
         Pageable pageable = PageRequest.of(request.getPage(), request.getSize(), request.getSort());
         return ResponseEntity.ok().body(songService.getAllSongs(pageable));
     }
 
-    @GetMapping("musician/{id}")
     @Operation(summary = "Obtiene todas las canciones de un artista por su ID")
+    @GetMapping("musician/{id}")
     public ResponseEntity<?> getAllSongsByMusicianId(@PathVariable Long id,@ParameterObject @Valid SongPageRequestDto request) {
         Pageable pageable = PageRequest.of(request.getPage(), request.getSize(), request.getSort());
         return ResponseEntity.ok().body(songService.getAllSongsByMusicianId(id,pageable));
     }
 
-    @GetMapping("/search")
     @Operation(summary = "Obtiene una lista paginada de canciones cuyo título o género contenga el término de búsqueda especificado.")
+    @GetMapping("/search")
     public ResponseEntity<?> searchSongs(@RequestParam(value = "search", required = false) String search, @ParameterObject @Valid SongPageRequestDto request) {
         Pageable pageable = PageRequest.of(request.getPage(), request.getSize(), request.getSort());
         return ResponseEntity.ok().body(songService.searchSongs(search,pageable));
     }
 
-    @PutMapping(value = "/{id}", consumes = "multipart/form-data")
     @Operation(summary = "Actualiza una canción por ID (requiere autenticación, solo el autor puede editar)", security = @SecurityRequirement(name = "bearer-key"))
+    @PutMapping(value = "/{id}", consumes = "multipart/form-data")
+    @PreAuthorize("hasRole('MUSICIAN')")
     public ResponseEntity<?> updateSong(@PathVariable Long id, @ModelAttribute @Valid SongUploadRequestDto request) {
         songService.updateSong(id,request);
         return ResponseEntity.ok().body(new ApiResponse<>("Los datos de la canción se han atualizado"));
     }
-
-//    ¿Se implementara borrado logico o fisico?
-//    @DeleteMapping("/{id}")
-//    @Operation(summary = "Elimina una canción por ID (requiere autenticación)", security = @SecurityRequirement(name = "bearer-key"))
-//    public ResponseEntity<?> deleteSong(@PathVariable Long id) {
-//        return ResponseEntity.ok("Canción eliminada");
-//    }
 }


### PR DESCRIPTION
- Se utiliza `SecurityConfig` para configurar endpoints públicos.
- Se movió la lógica de seguridad a anotaciones `@PreAuthorize` en los controladores.
- Se aplicaron restricciones de acceso según roles (`MUSICIAN`, `FAN`) en los endpoints correspondientes.