### PR TITLE
Adjust JWT environment variables and add missing test configurations

### DIFF
--- a/backend/src/main/java/com/footalentgroup/services/JwtService.java
+++ b/backend/src/main/java/com/footalentgroup/services/JwtService.java
@@ -30,7 +30,7 @@ public class JwtService {
     public JwtService(@Value("${jwt.secret}") String secret,
                       @Value("${jwt.issuer}") String issuer,
                       @Value("${jwt.expire}") int accessExpiration,
-                      @Value("${JWT_REFRESH_EXPIRE}") int refreshExpiration) {
+                      @Value("${jwt.refresh.token.expiration}") int refreshExpiration) {
         this.secret = secret;
         this.issuer = issuer;
         this.accessExpiration = accessExpiration;

--- a/backend/src/test/resources/logback-test.xml
+++ b/backend/src/test/resources/logback-test.xml
@@ -1,5 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <include resource="org/springframework/boot/logging/logback/base.xml" />
-    <logger name="org.springframework" level="WARN" />
+
+    <!-- Mostrar más detalles sobre Spring Boot -->
+    <logger name="org.springframework" level="INFO" />
+
+    <!-- Ver más detalles sobre el contexto de prueba -->
+    <logger name="org.springframework.test.context" level="DEBUG" />
+
+    <!-- Mostrar información de la capa de repositorios -->
+    <logger name="org.springframework.data.jpa.repository" level="DEBUG" />
+
+    <!-- Habilitar logs detallados de Hibernate (consultas SQL) -->
+    <logger name="org.hibernate.SQL" level="DEBUG" />
+
+    <!-- Mostrar detalles sobre la configuración de los tests -->
+    <logger name="org.springframework.boot.test" level="DEBUG" />
+
+    <!-- Definir el nivel de logs generales -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
 </configuration>

--- a/backend/src/test/resources/test.properties
+++ b/backend/src/test/resources/test.properties
@@ -1,7 +1,7 @@
 spring.profiles.active=test
 
 ## h2
-spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.datasource.driverClassName=org.h2.Driver
@@ -14,3 +14,16 @@ jwt.secret=secret
 jwt.issuer=test
 jwt.expire=5
 jwt.refresh.token.expiration=30
+
+## Cloudinary
+cloudinary.cloud-name=test-cloud
+cloudinary.api-key=test-key
+cloudinary.api-secret=test-secret
+
+## Email Configuration
+spring.mail.host=localhost
+spring.mail.port=3025
+spring.mail.username=test
+spring.mail.password=test
+spring.mail.properties.mail.smtp.auth=false
+spring.mail.properties.mail.smtp.starttls.enable=false


### PR DESCRIPTION
- Se reemplazó la variable de entorno de JwtService por el valor correcto de `properties`.
- Se agregaron configuraciones faltantes para **Cloudinary** y **email** en `test.properties`.
- Se verificó la carga correcta del `ApplicationContext` en los tests de integración.

## Pruebas

![tests](https://github.com/user-attachments/assets/fa396352-4dfc-48a5-a833-f2c12f20b714)
