### PR TITLE
Correct event query

### DIFF
--- a/backend/src/main/java/com/footalentgroup/repositories/EventRepository.java
+++ b/backend/src/main/java/com/footalentgroup/repositories/EventRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDate;
 
 public interface EventRepository extends JpaRepository<EventEntity, Long> {
-    Page<EventEntity> findByDateAfterOrderByDateAsc(LocalDate date, Pageable pageable);
-    Page<EventEntity> findByMusicianIdAndDateAfterOrderByDateAsc(Long musicianId, LocalDate date, Pageable pageable);
+    Page<EventEntity> findByDateGreaterThanEqualOrderByDateAsc(LocalDate date, Pageable pageable);
+    Page<EventEntity> findByMusicianIdAndDateGreaterThanEqualOrderByDateAsc(Long musicianId, LocalDate date, Pageable pageable);
 }

--- a/backend/src/main/java/com/footalentgroup/services/impl/EventServiceImpl.java
+++ b/backend/src/main/java/com/footalentgroup/services/impl/EventServiceImpl.java
@@ -44,7 +44,7 @@ public class EventServiceImpl implements EventService {
     @Override
     public PageResponseDto<EventSimpleResponseDto> search(int page, int size) {
         Page<EventEntity> eventPage = this.eventRepository
-                .findByDateAfterOrderByDateAsc(
+                .findByDateGreaterThanEqualOrderByDateAsc(
                         LocalDate.now(),
                         PageRequest.of(page, size, Sort.by("date").ascending())
                 );
@@ -55,7 +55,7 @@ public class EventServiceImpl implements EventService {
     @Override
     public PageResponseDto<EventSimpleResponseDto> searchByMusician(Long musicianId, int page, int size) {
         Page<EventEntity> eventPage = this.eventRepository
-                .findByMusicianIdAndDateAfterOrderByDateAsc(
+                .findByMusicianIdAndDateGreaterThanEqualOrderByDateAsc(
                         musicianId,
                         LocalDate.now(),
                         PageRequest.of(page, size, Sort.by("date").ascending())


### PR DESCRIPTION
Se corrigieron las consultas en `EventRepository`, reemplazando After por GreaterThanEqual para asegurar que se recuperen eventos desde la fecha especificada.