### PR TITLE
Convertir enlace de pago en un enlace interactivo

### DIFF
--- a/frontend/src/profile/fan/components/DonationDataReadOnlySection.tsx
+++ b/frontend/src/profile/fan/components/DonationDataReadOnlySection.tsx
@@ -1,4 +1,5 @@
 import LabeledFieldReadOnly from "./LabeledFieldReadOnly";
+import LabeledLinkReadOnly from "./LabeledLinkReadOnly";
 
 interface DonationDataReadOnlySectionProps {
   paymentLink?: string;
@@ -12,10 +13,9 @@ export const DonationDataReadOnlySection = ({
   cbu,
 }: DonationDataReadOnlySectionProps) => {
   return (
-    <section className="flex flex-col gap-2.5">
-      <LabeledFieldReadOnly label="🔗 LINK DE PAGO RÁPIDO" value={paymentLink} />
+    <section className="flex flex-col gap-4">
+      <LabeledLinkReadOnly label="LINK DE PAGO RÁPIDO" value={paymentLink} />
       <LabeledFieldReadOnly label="ALIAS" value={paymentAlias} />
-
       <LabeledFieldReadOnly label="CBU" value={cbu} />
     </section>
   );

--- a/frontend/src/profile/fan/components/LabeledFieldReadOnly.tsx
+++ b/frontend/src/profile/fan/components/LabeledFieldReadOnly.tsx
@@ -31,7 +31,7 @@ const LabeledFieldReadOnly = ({
 
   return (
     <div className={`text-ecos-blue flex w-full flex-col${className}`}>
-      <span>{label}</span>
+      <span className="mb-2">{label}</span>
 
       <div className="relative w-full">
         <div className="border-ecos-dark-grey w-full rounded-[20px] border px-3.5 py-2 text-sm break-words">
@@ -45,7 +45,7 @@ const LabeledFieldReadOnly = ({
             className="text-ecos-blue hover:text-ecos-blue-dark absolute top-1/2 right-2 -translate-y-1/2"
             aria-label="Copiar al portapapeles"
           >
-            <ClipboardCopyIcon className="h-4 w-4" />
+            <ClipboardCopyIcon className="h-4 w-4 hover:cursor-pointer" />
           </button>
         )}
 

--- a/frontend/src/profile/fan/components/LabeledLinkReadOnly.tsx
+++ b/frontend/src/profile/fan/components/LabeledLinkReadOnly.tsx
@@ -1,0 +1,23 @@
+interface LabeledLinkReadOnlyProps {
+  label: string;
+  value?: string;
+}
+
+const LabeledLinkReadOnly = ({ label, value }: LabeledLinkReadOnlyProps) => {
+  return value ? (
+    <a
+      href={value}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-ecos-blue hover:font-medium hover:underline"
+      aria-label={`Enlace a ${label}`}
+    >
+      <span className="mr-1 inline-block" aria-hidden="true">
+        🔗
+      </span>
+      <span>{label}</span>
+    </a>
+  ) : null;
+};
+
+export default LabeledLinkReadOnly;


### PR DESCRIPTION
- El enlace de pago ahora es clickeable en lugar de un texto estático.
- Se agregaron estilos a los íconos de copia (`ClipboardCopyIcon`).