### PR TITLE
Actualizar avatar de usuario instantáneamente tras editar foto de perfil

### DIFF
--- a/frontend/src/auth/components/UserMenu.tsx
+++ b/frontend/src/auth/components/UserMenu.tsx
@@ -21,16 +21,13 @@ const UserMenu = () => {
   const profileType = user?.role === "MUSICIAN" ? "musician" : "fan";
   const endpoint = user?.role === "MUSICIAN" ? `musician-profile/${id}` : `fan-profile/${id}`;
 
-  const { data: profile, refetch } = useProfileData<Musician | Fan>(profileType, id, endpoint);
+  const { data: profile } = useProfileData<Musician | Fan>(profileType, id, endpoint);
 
   const [profileImage, setProfileImage] = useState<string | undefined>(profile?.photoUrl);
 
   useEffect(() => {
-    if (profile?.photoUrl) {
-      setProfileImage(profile.photoUrl);
-    }
-    refetch();
-  }, [profile, refetch]);
+    setProfileImage(profile?.photoUrl);
+  }, [profile]);
 
   const handleLogOut = () => {
     handleLogout();

--- a/frontend/src/profile/components/forms/FormFanProfile.tsx
+++ b/frontend/src/profile/components/forms/FormFanProfile.tsx
@@ -38,7 +38,7 @@ const FormFanProfile = ({ onClose }: FormFanProfileProps) => {
     resolver: zodResolver(formFanProfileSchema),
   });
 
-  const { data } = useProfileForm<FormFanProfileSchema>(
+  const { data, refetch } = useProfileForm<FormFanProfileSchema>(
     "fan",
     id,
     `fan-profile/${id}`,
@@ -72,12 +72,12 @@ const FormFanProfile = ({ onClose }: FormFanProfileProps) => {
       mutate: (formData) => {
         mutate(formData, {
           onSuccess: () => {
+            refetch();
             toast.success("¡Perfil actualizado con éxito!");
             navigate(`/profile/fan/${id}`);
             onClose();
           },
-          onError: (error) => {
-            console.error("Error al actualizar perfil:", error);
+          onError: () => {
             toast.error("Ocurrió un error al guardar. Intentá nuevamente.");
             setError("root", {
               message: "Ocurrió un error al guardar. Intentá nuevamente.",

--- a/frontend/src/profile/components/forms/FormMusicianProfile.tsx
+++ b/frontend/src/profile/components/forms/FormMusicianProfile.tsx
@@ -40,7 +40,7 @@ const FormMusicianProfile = ({ onClose }: FormMusicianProfileProps) => {
     resolver: zodResolver(formMusicianProfileSchema),
   });
 
-  const { data } = useProfileForm<FormMusicianProfileSchema>(
+  const { data, refetch } = useProfileForm<FormMusicianProfileSchema>(
     "musician",
     id,
     "`musician-profile/${id}`",
@@ -74,12 +74,12 @@ const FormMusicianProfile = ({ onClose }: FormMusicianProfileProps) => {
       mutate: (formData) => {
         mutate(formData, {
           onSuccess: () => {
+            refetch();
             toast.success("¡Perfil actualizado con éxito!");
-            navigate("/profile/musician/edit");
+            navigate(`/profile/musician/${id}`);
             onClose();
           },
-          onError: (error) => {
-            console.error("Error al actualizar perfil:", error);
+          onError: () => {
             toast.error("Ocurrió un error al guardar. Intentá nuevamente.");
             setError("root", {
               message: "Ocurrió un error al guardar. Intentá nuevamente.",

--- a/frontend/src/profile/hooks/use-profile-form.ts
+++ b/frontend/src/profile/hooks/use-profile-form.ts
@@ -7,8 +7,8 @@ export const useProfileForm = <T extends object>(
   id: string,
   endpoint: string,
   formContext: UseFormReturn<T>,
-): { data: T | undefined; isLoading: boolean; isError: boolean } => {
-  const { data, isLoading, isError } = useApiQuery<{ data: T }>(queryKey, endpoint, id);
+) => {
+  const { data, isLoading, isError, refetch } = useApiQuery<{ data: T }>(queryKey, endpoint, id);
 
   const { reset } = formContext;
 
@@ -18,11 +18,5 @@ export const useProfileForm = <T extends object>(
     }
   }, [data, reset]);
 
-  useEffect(() => {
-    if (isError) {
-      console.error("Error en la API:", isError);
-    }
-  }, [isError]);
-
-  return { data: data?.data, isLoading, isError };
+  return { data: data?.data, isLoading, isError, refetch };
 };


### PR DESCRIPTION
- El avatar se actualiza instantáneamente al modificar la foto de perfil. Es decir, ya no es necesario recargar la página para ver los cambios.
- Además, se corrigió la ruta a la que es redireccionado el músico después de actualizar sus datos, para que vea la vista de su perfil y no la edición.
- Se eliminaron prints de pantalla.