### PR TITLE
Eliminar vite-plugin-svgr y corregir uso de SVGs sin ?react

### DIFF
--- a/frontend/src/app/layout/Footer/Footer.tsx
+++ b/frontend/src/app/layout/Footer/Footer.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router";
-import LinkedInIcon from "@/assets/RRSS/linkedin.svg?react";
-import InstagramIcon from "@/assets/RRSS/instagram.svg?react";
+import LinkedInIcon from "@/assets/RRSS/linkedin.svg";
+import InstagramIcon from "@/assets/RRSS/instagram.svg";
 import Logo from "@/assets/EcosLogoFooter.webp";
 
 export const Footer = () => {
@@ -45,7 +45,7 @@ export const Footer = () => {
               aria-label="Visitar perfil de LinkedIn de ECOS"
               className="transition-transform hover:scale-105 focus-visible:scale-105"
             >
-              <LinkedInIcon className="size-10" />
+              <img src={LinkedInIcon} alt="Icono Linkedin" className="size-10" />
             </Link>
             <Link
               title="Instagram de ECOS"
@@ -55,7 +55,7 @@ export const Footer = () => {
               aria-label="Visitar perfil de Instagram de ECOS"
               className="transition-transform hover:scale-105 focus-visible:scale-105"
             >
-              <InstagramIcon className="size-10" />
+              <img src={InstagramIcon} alt="Icono Instagram" className="size-10" />
             </Link>
           </div>
         </div>

--- a/frontend/src/app/ui/Modal.tsx
+++ b/frontend/src/app/ui/Modal.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from "react";
 import { createPortal } from "react-dom";
-import { CloseArrow } from "@/auth/components/ui/icons";
+import { CloseArrow } from "@/auth/components/ui/Icons";
 
 interface ModalProps extends PropsWithChildren {
   onClose: () => void;

--- a/frontend/src/auth/components/ForgotPasswordForm.tsx
+++ b/frontend/src/auth/components/ForgotPasswordForm.tsx
@@ -3,7 +3,7 @@ import { SubmitHandler, useForm } from "react-hook-form";
 import { z } from "zod";
 import Button from "@/app/ui/Button";
 import Input from "@/app/ui/Input";
-import { EyeOff, EyeOn } from "./ui/icons";
+import { EyeOff, EyeOn } from "./ui/Icons";
 import { useState } from "react";
 
 interface ForgotPasswordFormProps {

--- a/frontend/src/auth/components/LoginForm.tsx
+++ b/frontend/src/auth/components/LoginForm.tsx
@@ -3,7 +3,7 @@ import { SubmitHandler, useForm } from "react-hook-form";
 import { z } from "zod";
 import Button from "@/app/ui/Button";
 import Input from "@/app/ui/Input";
-import { EyeOff, EyeOn } from "./ui/icons";
+import { EyeOff, EyeOn } from "./ui/Icons";
 import { useState } from "react";
 import { useApiMutation } from "@/shared/hooks/use-api-mutation";
 import { useAuth } from "../hooks/use-auth";

--- a/frontend/src/auth/components/RegistrationForm.tsx
+++ b/frontend/src/auth/components/RegistrationForm.tsx
@@ -3,7 +3,7 @@ import Input from "@/app/ui/Input";
 import { z } from "zod";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { EyeOff, EyeOn } from "./ui/icons";
+import { EyeOff, EyeOn } from "./ui/Icons";
 import { useApiMutation } from "@/shared/hooks/use-api-mutation";
 import { useAuth } from "../hooks/use-auth";
 import { useState } from "react";

--- a/frontend/src/auth/components/UserMenu.tsx
+++ b/frontend/src/auth/components/UserMenu.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useAuth } from "@/auth/hooks/use-auth";
 import { useNavigate } from "react-router";
-import { Settings, Avatar, Logout, UserProfileIcon, EditContainer } from "./ui/icons";
+import { Settings, Avatar, Logout, UserProfileIcon, EditContainer } from "./ui/Icons";
 import ProfileUserModal from "@/profile/components/ProfileUserModal";
 import { useProfileData } from "../hooks/useProfileData";
 import { Musician, Fan } from "../types";

--- a/frontend/src/profile/components/forms/components/profilePhotoModal/ProfilePhotoModal.tsx
+++ b/frontend/src/profile/components/forms/components/profilePhotoModal/ProfilePhotoModal.tsx
@@ -1,6 +1,6 @@
 import Modal from "@/app/ui/Modal";
 import { useState, useEffect } from "react";
-import ProfileImagen from "./components/ProfileImagen";
+import ProfileImage from "./components/ProfileImage";
 import ImageUpload from "./components/ImageUpdload";
 import Button from "@/app/ui/Button";
 import { Edit, Trash } from "@/profile/components/ui/Icons";
@@ -11,7 +11,7 @@ interface ProfilePhotoPropsModal {
   open: boolean;
   mode: Transition;
   onClose: () => void;
-  openProfileImagen: (file: File | null, imageUrl: string | null) => void;
+  openProfileImage: (file: File | null, imageUrl: string | null) => void;
   initialImage?: string | null;
   currentImage?: string | null;
 }
@@ -20,7 +20,7 @@ const ProfilePhotoModal = ({
   open,
   mode,
   onClose,
-  openProfileImagen,
+  openProfileImage,
   currentImage,
 }: ProfilePhotoPropsModal) => {
   const [transition, setTransition] = useState<Transition>(mode);
@@ -46,7 +46,7 @@ const ProfilePhotoModal = ({
 
   const handleSave = () => {
     if (file && preview) {
-      openProfileImagen(file, preview);
+      openProfileImage(file, preview);
       onClose();
     }
   };
@@ -58,7 +58,7 @@ const ProfilePhotoModal = ({
       <h2 className="px-6 py-2 text-start text-2xl font-medium">IMAGEN DE PERFIL</h2>
       {transition === "edit" && (
         <div className="flex flex-col items-center justify-around gap-20 px-3.5 pb-10">
-          <ProfileImagen profileImage={preview ?? null} />
+          <ProfileImage profileImage={preview ?? null} />
           <div className="flex items-center gap-11">
             <Button
               startIcon={<Edit className="h-10 w-10 stroke-white" />}
@@ -75,7 +75,7 @@ const ProfilePhotoModal = ({
               onClick={() => {
                 setFile(null);
                 setPreview(null);
-                openProfileImagen(null, null);
+                openProfileImage(null, null);
                 onClose();
               }}
             />

--- a/frontend/src/profile/components/forms/components/profilePhotoModal/components/ProfileImage.tsx
+++ b/frontend/src/profile/components/forms/components/profilePhotoModal/components/ProfileImage.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from "react";
-import { Avatar } from "@/auth/components/ui/icons";
+import { Avatar } from "@/auth/components/ui/Icons";
 
-interface ProfileImagenProps {
+interface ProfileImageProps {
   profileImage: string | File | null;
 }
 
-const ProfileImagen = ({ profileImage }: ProfileImagenProps) => {
+const ProfileImage = ({ profileImage }: ProfileImageProps) => {
   const [imageSrc, setImageSrc] = useState<string | null>(null);
 
   useEffect(() => {
@@ -33,7 +33,7 @@ const ProfileImagen = ({ profileImage }: ProfileImagenProps) => {
           <img
             src={imageSrc}
             className="h-60 w-60 rounded-full object-cover"
-            alt="Imagen de perfil"
+            alt="Image de perfil"
           />
         ) : (
           <Avatar className="h-60 w-60" detailColor="#FFFFFF" bgColor="var(--color-ecos-blue)" />
@@ -43,4 +43,4 @@ const ProfileImagen = ({ profileImage }: ProfileImagenProps) => {
   );
 };
 
-export default ProfileImagen;
+export default ProfileImage;

--- a/frontend/src/profile/components/forms/components/sections/ProfilePhotoSection.tsx
+++ b/frontend/src/profile/components/forms/components/sections/ProfilePhotoSection.tsx
@@ -1,5 +1,5 @@
-import ProfileImagen from "../profilePhotoModal/components/ProfileImagen";
-import { Avatar } from "@/auth/components/ui/icons";
+import ProfileImage from "../profilePhotoModal/components/ProfileImage";
+import { Avatar } from "@/auth/components/ui/Icons";
 import { Edit } from "../../../ui/Icons";
 import { useState } from "react";
 import ProfilePhotoModal from "../profilePhotoModal/ProfilePhotoModal";
@@ -11,10 +11,10 @@ interface ProfilePhotoProps {
 }
 
 const ProfilePhotoSection = ({ profileImage, onImageChange, className }: ProfilePhotoProps) => {
-  const [openProfileImagenModal, setOpenProfileImagenModal] = useState(false);
+  const [openProfileImageModal, setOpenProfileImageModal] = useState(false);
 
   const handleCloseModal = () => {
-    setOpenProfileImagenModal(false);
+    setOpenProfileImageModal(false);
   };
 
   const handleProfileImageChange = (file: File | null) => {
@@ -28,7 +28,7 @@ const ProfilePhotoSection = ({ profileImage, onImageChange, className }: Profile
       <div className="relative">
         <div className="h-60 w-60 rounded-full">
           {profileImage ? (
-            <ProfileImagen profileImage={profileImage} />
+            <ProfileImage profileImage={profileImage} />
           ) : (
             <Avatar className="h-60 w-60" detailColor="#FFFFFF" bgColor="var(--color-ecos-blue)" />
           )}
@@ -37,19 +37,19 @@ const ProfilePhotoSection = ({ profileImage, onImageChange, className }: Profile
           type="button"
           className="bg-ecos-base absolute right-14 -bottom-6 flex h-20 w-20 items-center justify-center rounded-full drop-shadow-md"
           onClick={() => {
-            setOpenProfileImagenModal(true);
+            setOpenProfileImageModal(true);
           }}
         >
           <Edit className="stroke-ecos-blue" />
         </button>
       </div>
 
-      {openProfileImagenModal && (
+      {openProfileImageModal && (
         <ProfilePhotoModal
           mode="edit"
           open={true}
           onClose={handleCloseModal}
-          openProfileImagen={handleProfileImageChange}
+          openProfileImage={handleProfileImageChange}
           currentImage={
             profileImage instanceof File ? URL.createObjectURL(profileImage) : profileImage
           }

--- a/frontend/src/profile/musician/components/FollowArtist.tsx
+++ b/frontend/src/profile/musician/components/FollowArtist.tsx
@@ -1,8 +1,8 @@
 import { Link, useParams } from "react-router";
 import { useApiQuery } from "@/shared/hooks/use-api-query";
-import InstagramIcon from "@/assets/RRSS/instagram.svg?react";
-import SpotifyIcon from "@/assets/RRSS/spotify.svg?react";
-import YoutubeIcon from "@/assets/RRSS/youtube.svg?react";
+import InstagramIcon from "@/assets/RRSS/instagram.svg";
+import SpotifyIcon from "@/assets/RRSS/spotify.svg";
+import YoutubeIcon from "@/assets/RRSS/youtube.svg";
 import { type MusicianProfile } from "../musician-types";
 
 const FollowArtist = () => {
@@ -25,7 +25,12 @@ const FollowArtist = () => {
             aria-label="Visitar perfil de Spotify"
             className="transition-transform hover:scale-105 focus-visible:scale-105"
           >
-            <SpotifyIcon className="size-12 cursor-pointer" aria-hidden="true" />
+            <img
+              src={SpotifyIcon}
+              alt="Logo Spotify"
+              className="size-12 cursor-pointer"
+              aria-hidden="true"
+            />
           </Link>
         )}
 
@@ -38,7 +43,12 @@ const FollowArtist = () => {
             aria-label="Visitar perfil de Youtube"
             className="transition-transform hover:scale-105 focus-visible:scale-105"
           >
-            <YoutubeIcon className="size-12 cursor-pointer" aria-hidden="true" />
+            <img
+              src={YoutubeIcon}
+              alt="Logo Youtube"
+              className="size-12 cursor-pointer"
+              aria-hidden="true"
+            />
           </Link>
         )}
 
@@ -51,7 +61,12 @@ const FollowArtist = () => {
             aria-label="Visitar perfil de Instagram"
             className="transition-transform hover:scale-105 focus-visible:scale-105"
           >
-            <InstagramIcon className="size-12 cursor-pointer" aria-hidden="true" />
+            <img
+              src={InstagramIcon}
+              alt="Logo Instagram"
+              className="size-12 cursor-pointer"
+              aria-hidden="true"
+            />
           </Link>
         )}
       </div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
-import svgr from "vite-plugin-svgr";
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -12,7 +11,7 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
-  plugins: [react(), tailwindcss(), svgr()],
+  plugins: [react(), tailwindcss()],
   test: {
     exclude: ["node_modules", "dist", "public"],
     globals: true,


### PR DESCRIPTION
Cambios realizados:
- Se removió `vite-plugin-svgr` del proyecto (vite-config-ts (anteriormente ya había sido eliminado de package.json)).
- Se actualizaron los imports de íconos SVG en todos los componentes que aún utilizaban `?react`.
- Los íconos ahora se usan como imágenes estáticas mediante `<img src=... />`.
- Se corrigió un error al importar íconos desde la carpeta auth/components/ui.
- Se renombró el componente `ProfileImagen` a `ProfileImage` para evitar spanglish. 