### PR TITLE
ProfileFanPage:  ajustar padding-x y estilos de CardSong para alinear elementos

### DIFF
--- a/frontend/src/profile/fan/ProfileFanPage.tsx
+++ b/frontend/src/profile/fan/ProfileFanPage.tsx
@@ -22,16 +22,13 @@ const ProfileFanPage = () => {
   return (
     <div className="bg-ecos-base-2 flex w-screen flex-col items-center space-y-20">
       <img src={ImageBanner} alt="banner" className="w-full object-cover" />
-
-      <div className="w-full space-y-20 px-4 md:px-18 lg:px-40">
+      <div className="px-sections w-full space-y-20">
         <div className="text-ecos-blue">
           <h1 className="mb-2 text-start text-4xl font-medium sm:text-5xl">¡BIENVENIDO!</h1>
           <h3 className="text-2xl sm:text-3xl">{user.name}</h3>
         </div>
-
         <FavoriteSongList />
         <MusicSearch />
-
         <FeaturedArtists />
         <UpcomingEvents />
       </div>

--- a/frontend/src/profile/fan/components/CardSong.tsx
+++ b/frontend/src/profile/fan/components/CardSong.tsx
@@ -89,7 +89,7 @@ const CardSongFavorite = ({
 
   return (
     <>
-      <div className="group card-shadow relative max-w-[390px] justify-items-center space-y-6 rounded-[40px] bg-white px-[25px] py-[42px] sm:px-8 sm:py-10">
+      <div className="group card-shadow relative flex max-w-[390px] flex-col items-center justify-between space-y-6 rounded-[40px] bg-white px-[25px] py-[42px] sm:px-8 sm:py-10">
         <div className="w-full">
           <CloseIcon
             className="absolute top-5 right-5 z-10 h-[43px] w-[43px] cursor-pointer"


### PR DESCRIPTION
- Se modifica el padding-x general de la página para mantener consistencia con el diseño en Figma.
- Se corrigen los estilos de las CardSong para que el reproductor y el botón de "Donar" se alineen correctamente, independientemente de la altura del título de la canción.