### PR TITLE
Lógica de busqueda

### DIFF
--- a/frontend/src/app/components/MusicSearch.tsx
+++ b/frontend/src/app/components/MusicSearch.tsx
@@ -1,19 +1,89 @@
 import Input from "@/app/ui/Input";
 import MenuIcon from "@/app/ui/MenuIcon";
 import Lens from "@/app/ui/LensIcon";
+import { useState } from "react";
+import { useApiQuery } from "@/shared/hooks/use-api-query";
+import { type ApiSongs } from "@/profile/musician/musician-types";
+import { type MusicianApiResponse } from "../types/musician-profile-search";
+import useDebounce from "@/shared/hooks/use-debounce";
+import { SearchResult } from "../types/search-normalize-data";
+import SearchCard from "./SearchCard";
+import { Spinner } from "../ui/Spinner";
 
 const MusicSearch = () => {
+  const [query, setQuery] = useState("");
+  const debouncedQuery = useDebounce(query);
+
+  const isEnabled = debouncedQuery.trim().length > 0;
+
+  const { data: songs, isFetching: isSongsPending } = useApiQuery<ApiSongs>(
+    "searchSongs",
+    `songs/search?search=${debouncedQuery}`,
+    debouncedQuery,
+    isEnabled,
+  );
+
+  const { data: musicians, isFetching: isMusiciansPending } = useApiQuery<MusicianApiResponse>(
+    "searchMusicians",
+    `musician-profile/search?search=${debouncedQuery}`,
+    debouncedQuery,
+    isEnabled,
+  );
+
+  const musicianResults: SearchResult[] =
+    musicians?.items.map(({ description, genre, id, photoUrl, stageName }) => ({
+      type: "musician",
+      id: id,
+      photoUrl: photoUrl,
+      stageName: stageName,
+      genre: genre,
+      description: description,
+    })) ?? [];
+
+  const songResults: SearchResult[] =
+    songs?.items.map((song) => ({
+      type: "song",
+      id: song.id,
+      title: song.title,
+      genre: song.genre,
+      photoUrl: song.musicianInfo.photoUrl,
+      stageName: song.musicianInfo.stageName,
+      artistId: song.musicianInfo.artistId,
+    })) ?? [];
+
+  const combinedResults: SearchResult[] = [...musicianResults, ...songResults];
+
   return (
     <section id="explorar" className="flex w-full flex-col items-center justify-center gap-y-8">
       <h1 className="subtitles text-start uppercase md:text-center">
         Encuentra tu artista favorito
       </h1>
-      <Input
-        placeholder="Busca Artista, Album, Canción"
-        startIcon={<MenuIcon />}
-        endIcon={<Lens />}
-        classNameContainer="container-search"
-      />
+      <div className="group relative">
+        <Input
+          placeholder="Busca Artista, Album, Canción"
+          startIcon={<MenuIcon />}
+          endIcon={
+            isSongsPending && isMusiciansPending ? <Spinner className="m-2 size-6" /> : <Lens />
+          }
+          classNameContainer="container-search group"
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value);
+          }}
+        />
+
+        {combinedResults.length > 0 ? (
+          <div className="border-ecos-input-placeholder absolute z-10 mt-1 hidden max-h-[300px] w-full overflow-y-auto rounded-lg border bg-white shadow-[0_4px_4px_rgba(0,0,0,.25)] group-focus-within:block md:right-10 md:left-10 md:max-w-1/2">
+            {combinedResults.map((result) => (
+              <SearchCard key={`${result.type}-${result.id.toString()}`} result={result} />
+            ))}
+          </div>
+        ) : (
+          <div className="border-ecos-input-placeholder text-ecos-blue absolute z-10 mt-1 hidden min-h-[100px] w-full place-content-center overflow-y-auto rounded-lg border bg-white font-bold shadow-[0_4px_4px_rgba(0,0,0,.25)] group-focus-within:grid md:right-10 md:left-10 md:max-w-1/2">
+            No hay resultados
+          </div>
+        )}
+      </div>
     </section>
   );
 };

--- a/frontend/src/app/components/SearchCard.tsx
+++ b/frontend/src/app/components/SearchCard.tsx
@@ -1,0 +1,43 @@
+import { useNavigate } from "react-router";
+import { type SearchResult } from "../types/search-normalize-data";
+import defaultImage from "@/assets/image.webp";
+
+interface SearchCardProps {
+  result: SearchResult;
+}
+const SearchCard = ({ result }: SearchCardProps) => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    const id = result.type === "song" ? result.artistId : result.id;
+    navigate(`/profile/musician/${id.toString()}`);
+  };
+
+  return (
+    <div
+      onClick={handleClick}
+      className="hover:bg-ecos-base-2 flex cursor-pointer items-center gap-3 bg-white p-3"
+    >
+      <img
+        src={result.photoUrl ?? defaultImage}
+        alt={result.stageName ?? ""}
+        className="size-15 rounded-full object-cover"
+      />
+
+      <div className="text-ecos-blue">
+        <h4 className="m-0 font-bold">{result.stageName}</h4>
+        <p className="m-0 text-sm">{result.genre}</p>
+
+        {result.type === "musician" && (
+          <p className="text-ecos-input-placeholder line-clamp-2 text-xs">{result.description}</p>
+        )}
+
+        {result.type === "song" && (
+          <p className="text-ecos-input-placeholder text-xs">🎵 {result.title}</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SearchCard;

--- a/frontend/src/app/types/musician-profile-search.d.ts
+++ b/frontend/src/app/types/musician-profile-search.d.ts
@@ -1,0 +1,17 @@
+interface MusicianItem {
+  id: number;
+  photoUrl: string;
+  stageName: string;
+  genre: string;
+  description: string;
+}
+
+export interface MusicianApiResponse {
+  items: MusicianItem[];
+  page: number;
+  size: number;
+  totalPages: number;
+  totalItems: number;
+  first: boolean;
+  last: boolean;
+}

--- a/frontend/src/app/types/search-normalize-data.d.ts
+++ b/frontend/src/app/types/search-normalize-data.d.ts
@@ -1,0 +1,18 @@
+export type SearchResult =
+  | {
+      type: "musician";
+      id: number;
+      photoUrl: string;
+      stageName: string;
+      genre: string;
+      description: string;
+    }
+  | {
+      type: "song";
+      id: number;
+      title: string | null;
+      genre: string;
+      photoUrl: string | null;
+      stageName: string | null;
+      artistId: number;
+    };

--- a/frontend/src/profile/musician/musician-types.ts
+++ b/frontend/src/profile/musician/musician-types.ts
@@ -46,7 +46,9 @@ interface Item {
 }
 
 interface MusicianInfo {
+  artistId: number;
   stageName: string | null;
+  photoUrl: string | null;
   artistName: string;
   spotifyUrl: string | null;
   youtubeUrl: string | null;

--- a/frontend/src/shared/hooks/use-debounce.ts
+++ b/frontend/src/shared/hooks/use-debounce.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+function useDebounce<T>(value: T, delay = 500): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+export default useDebounce;


### PR DESCRIPTION
- Se agrego el funcionamiento de busqueda en el Home
- Ahora en el buscador, se pueden buscar concurrencias, tanto por canciones por como artistas/músicos
- Se manejan los estados de carga del mismo, mostrando un spinner en lugar de la lupa cuando se esta realizando el fetching
- Al perder el focus del input, los resultados se ocultan
- Si no hay resultados se renderiza un cartel para indicarle al usuario
- Se agrego un custom hook, useDebouce, que retrasa el envio de la informacion al backend, para evitar que en cada keydown, se realice una llamada

![image](https://github.com/user-attachments/assets/4ca6d25a-6985-4287-bc45-eca43b6c987a)

![image](https://github.com/user-attachments/assets/0626d0a4-1261-49fa-85bd-c164d06d6c51)
